### PR TITLE
Update demos to use norfair-enough package

### DIFF
--- a/demos/3d_track/Dockerfile
+++ b/demos/3d_track/Dockerfile
@@ -10,6 +10,6 @@ RUN pip install --upgrade pip && \
     pip install mediapipe==0.8.11 && \
     pip install opencv-python==4.5.5.64
 
-RUN pip install git+https://github.com/tryolabs/norfair.git@master#egg=norfair
+RUN pip install norfair-enough
 
 WORKDIR /demo/src/

--- a/demos/alphapose/Dockerfile
+++ b/demos/alphapose/Dockerfile
@@ -44,6 +44,6 @@ RUN pip3 install gdown==4.4.0 && \
 # if you want to use yolox-x as the detector
 # RUN wget -P /root/AlphaPose/detector/yolox/data/ https://github.com/Megvii-BaseDetection/YOLOX/releases/download/0.1.0/yolox_x.pth
 
-RUN pip install git+https://github.com/tryolabs/norfair.git@master#egg=norfair
+RUN pip install norfair-enough
 
 WORKDIR /root/AlphaPose/

--- a/demos/camera_motion/Dockerfile
+++ b/demos/camera_motion/Dockerfile
@@ -1,6 +1,6 @@
 FROM ultralytics/yolov5:v6.2
 
 # Install Norfair
-RUN pip install git+https://github.com/tryolabs/norfair.git@master#egg=norfair
+RUN pip install norfair-enough
 
 WORKDIR /demo/src/

--- a/demos/colab/colab_demo.ipynb
+++ b/demos/colab/colab_demo.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "<a href=\"https://colab.research.google.com/github/tryolabs/norfair/blob/master/demos/colab/colab_demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-   ]
+   "source": "<a href=\"https://colab.research.google.com/github/akator-de/norfair-enough/blob/main/demos/colab/colab_demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
   },
   {
    "cell_type": "markdown",
@@ -41,10 +39,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "! wget \"https://raw.githubusercontent.com/tryolabs/norfair/master/demos/colab/requirements.txt\" -O requirements.txt\n",
-    "! pip install -r requirements.txt"
-   ]
+   "source": "! wget \"https://raw.githubusercontent.com/akator-de/norfair-enough/main/demos/colab/requirements.txt\" -O requirements.txt\n! pip install -r requirements.txt"
   },
   {
    "cell_type": "markdown",
@@ -83,13 +78,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "! wget \"https://raw.githubusercontent.com/tryolabs/norfair/master/demos/colab/demo.py\"\n",
-    "! wget \"https://raw.githubusercontent.com/tryolabs/norfair/master/demos/colab/draw.py\"\n",
-    "! wget \"https://raw.githubusercontent.com/tryolabs/norfair/master/demos/colab/yolo.py\"\n",
-    "\n",
-    "! python demo.py sample_10s.mp4 --classes 0"
-   ]
+   "source": "! wget \"https://raw.githubusercontent.com/akator-de/norfair-enough/main/demos/colab/demo.py\"\n! wget \"https://raw.githubusercontent.com/akator-de/norfair-enough/main/demos/colab/draw.py\"\n! wget \"https://raw.githubusercontent.com/akator-de/norfair-enough/main/demos/colab/yolo.py\"\n\n! python demo.py sample_10s.mp4 --classes 0"
   },
   {
    "cell_type": "markdown",

--- a/demos/colab/colab_demo.ipynb
+++ b/demos/colab/colab_demo.ipynb
@@ -39,7 +39,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "! wget \"https://raw.githubusercontent.com/akator-de/norfair-enough/main/demos/colab/requirements.txt\" -O requirements.txt\n! pip install -r requirements.txt"
+   "source": "NORFAIR_REF = \"v2.4.0\"\nRAW_BASE = f\"https://raw.githubusercontent.com/akator-de/norfair-enough/{NORFAIR_REF}/demos/colab\"\n! wget \"{RAW_BASE}/requirements.txt\" -O requirements.txt\n! pip install -r requirements.txt"
   },
   {
    "cell_type": "markdown",
@@ -78,7 +78,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "! wget \"https://raw.githubusercontent.com/akator-de/norfair-enough/main/demos/colab/demo.py\"\n! wget \"https://raw.githubusercontent.com/akator-de/norfair-enough/main/demos/colab/draw.py\"\n! wget \"https://raw.githubusercontent.com/akator-de/norfair-enough/main/demos/colab/yolo.py\"\n\n! python demo.py sample_10s.mp4 --classes 0"
+   "source": "NORFAIR_REF = \"v2.4.0\"\nRAW_BASE = f\"https://raw.githubusercontent.com/akator-de/norfair-enough/{NORFAIR_REF}/demos/colab\"\n! wget \"{RAW_BASE}/demo.py\"\n! wget \"{RAW_BASE}/draw.py\"\n! wget \"{RAW_BASE}/yolo.py\"\n\n! python demo.py sample_10s.mp4 --classes 0"
   },
   {
    "cell_type": "markdown",

--- a/demos/colab/requirements.txt
+++ b/demos/colab/requirements.txt
@@ -3,4 +3,4 @@ torchvision==0.13.1
 rich==12.5.1
 opencv-python==4.6.0.66
 tqdm==4.64.1
-git+https://github.com/tryolabs/norfair.git@master
+norfair-enough

--- a/demos/colab/requirements.txt
+++ b/demos/colab/requirements.txt
@@ -3,4 +3,4 @@ torchvision==0.13.1
 rich==12.5.1
 opencv-python==4.6.0.66
 tqdm==4.64.1
-norfair-enough
+norfair-enough==2.4.0

--- a/demos/detectron2/Dockerfile
+++ b/demos/detectron2/Dockerfile
@@ -14,7 +14,7 @@ RUN pip install 'git+https://github.com/facebookresearch/detectron2.git'
 # For some reason it doesn't work with latest version of OpenCV
 RUN pip install opencv-python==4.5.5.64
 
-RUN pip install git+https://github.com/tryolabs/norfair.git@master#egg=norfair
+RUN pip install norfair-enough
 
 WORKDIR /demo/src/
 

--- a/demos/detectron2/Dockerfile
+++ b/demos/detectron2/Dockerfile
@@ -14,7 +14,7 @@ RUN pip install 'git+https://github.com/facebookresearch/detectron2.git'
 # For some reason it doesn't work with latest version of OpenCV
 RUN pip install opencv-python==4.5.5.64
 
-RUN pip install norfair-enough
+RUN pip install norfair-enough==2.4.0
 
 WORKDIR /demo/src/
 

--- a/demos/keypoints_bounding_boxes/Dockerfile
+++ b/demos/keypoints_bounding_boxes/Dockerfile
@@ -50,6 +50,6 @@ RUN cmake \
     ..
 RUN make --jobs `nproc`
 
-RUN pip install git+https://github.com/tryolabs/norfair.git@master
+RUN pip install norfair-enough
 
 WORKDIR /demo/src

--- a/demos/mmdetection/Dockerfile
+++ b/demos/mmdetection/Dockerfile
@@ -46,6 +46,6 @@ WORKDIR /mmdetection
 ADD https://download.openmmlab.com/mmdetection/v2.0/faster_rcnn/faster_rcnn_r50_fpn_1x_coco/faster_rcnn_r50_fpn_1x_coco_20200130-047c8118.pth faster_rcnn_r50_fpn_1x_coco_20200130-047c8118.pth
 
 WORKDIR /demo
-RUN pip install git+https://github.com/tryolabs/norfair.git@master
+RUN pip install norfair-enough
 
 WORKDIR /demo/src

--- a/demos/motmetrics4norfair/Dockerfile
+++ b/demos/motmetrics4norfair/Dockerfile
@@ -35,6 +35,6 @@ RUN pip install -r requirements.txt && \
     pip install cython_bbox
 
 WORKDIR /
-RUN pip install git+https://github.com/tryolabs/norfair.git@master#egg=norfair[metrics,video]
+RUN pip install norfair-enough[metrics,video]
 
 WORKDIR /demo/src/

--- a/demos/openpose/Dockerfile
+++ b/demos/openpose/Dockerfile
@@ -50,6 +50,6 @@ RUN cmake \
     ..
 RUN make --jobs `nproc`
 
-RUN pip install git+https://github.com/tryolabs/norfair.git@master
+RUN pip install norfair-enough
 
 WORKDIR /demo/src

--- a/demos/profiling/Dockerfile
+++ b/demos/profiling/Dockerfile
@@ -25,6 +25,6 @@ RUN python setup.py install && \
     gdown --id 1XYDdCUdiF2xxx4rznmLb62SdOUZuoNbd
 
 WORKDIR /
-RUN pip install git+https://github.com/tryolabs/norfair.git@master
+RUN pip install norfair-enough
 
 WORKDIR /demo/src/

--- a/demos/profiling/Dockerfile
+++ b/demos/profiling/Dockerfile
@@ -11,7 +11,7 @@ COPY requirements.txt requirements.txt
 RUN pip install --upgrade pip && \
     pip install -r requirements.txt
 
-# install torch2trt and trt-pose and norfair
+# install torch2trt and trt-pose and norfair-enough
 WORKDIR /
 RUN git clone https://github.com/NVIDIA-AI-IOT/torch2trt && \
     git clone https://github.com/NVIDIA-AI-IOT/trt_pose

--- a/demos/reid/Dockerfile
+++ b/demos/reid/Dockerfile
@@ -11,6 +11,6 @@ WORKDIR /reid
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 
-RUN pip install git+https://github.com/tryolabs/norfair.git@master
+RUN pip install norfair-enough
 
 WORKDIR /demo/src/

--- a/demos/reid/Dockerfile
+++ b/demos/reid/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.8-slim-buster
 
 RUN apt update && \
-    apt install -y libgl1 libglib2.0-0 git && \
+    apt install -y libgl1 libglib2.0-0 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/demos/sahi/Dockerfile
+++ b/demos/sahi/Dockerfile
@@ -12,6 +12,6 @@ WORKDIR /sahi
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 
-RUN pip install git+https://github.com/tryolabs/norfair.git
+RUN pip install norfair-enough
 
 WORKDIR /demo/src/

--- a/demos/yolo_nas/Dockerfile
+++ b/demos/yolo_nas/Dockerfile
@@ -12,7 +12,7 @@ RUN pip install -r https://raw.githubusercontent.com/Deci-AI/super-gradients/mas
     # For some reason it doesn't work with latest version of OpenCV \ --> AttributeError: partially initialized module 'cv2' has no attribute '_registerMatType' (most likely due to a circular import)
     pip install opencv-python==4.5.5.64
 
-RUN pip install git+https://github.com/tryolabs/norfair.git@master#egg=norfair
+RUN pip install norfair-enough
 
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt

--- a/demos/yolov4/Dockerfile
+++ b/demos/yolov4/Dockerfile
@@ -19,6 +19,6 @@ WORKDIR /demo
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 
-RUN pip install git+https://github.com/tryolabs/norfair.git@master
+RUN pip install norfair-enough
 
 WORKDIR /demo/src

--- a/demos/yolov5/Dockerfile
+++ b/demos/yolov5/Dockerfile
@@ -1,6 +1,6 @@
 FROM ultralytics/yolov5:v6.2
 
-# Install Norfair
+# Install norfair-enough
 RUN pip install norfair-enough
 
 WORKDIR /demo/src/

--- a/demos/yolov5/Dockerfile
+++ b/demos/yolov5/Dockerfile
@@ -1,6 +1,6 @@
 FROM ultralytics/yolov5:v6.2
 
 # Install Norfair
-RUN pip install git+https://github.com/tryolabs/norfair.git@master#egg=norfair
+RUN pip install norfair-enough
 
 WORKDIR /demo/src/

--- a/demos/yolov7/Dockerfile
+++ b/demos/yolov7/Dockerfile
@@ -12,6 +12,6 @@ RUN pip install -r https://raw.githubusercontent.com/WongKinYiu/yolov7/main/requ
     # For some reason it doesn't work with latest version of OpenCV \
     pip install opencv-python==4.5.5.64
 
-RUN pip install git+https://github.com/tryolabs/norfair.git@master#egg=norfair
+RUN pip install norfair-enough
 
 WORKDIR /demo/src/


### PR DESCRIPTION
## Summary
- Replace `pip install git+https://github.com/tryolabs/norfair.git@master#egg=norfair` with `pip install norfair-enough` in all Dockerfiles
- Update Colab notebook URLs to point to akator-de/norfair-enough repository
- Update colab requirements.txt to use norfair-enough

## Changed files
- 14 Dockerfiles updated to use `norfair-enough` package
- `demos/colab/colab_demo.ipynb` - Updated GitHub URLs
- `demos/colab/requirements.txt` - Changed package name

## Test plan
- [ ] Verify Colab notebook opens and runs correctly
- [ ] Verify Docker builds work with the new package name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated demo environment configurations across multiple Docker builds and the Colab notebook to reflect revised dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->