### PR TITLE
Fix critical bugs found in code review

### DIFF
--- a/norfair/drawing/absolute_grid.py
+++ b/norfair/drawing/absolute_grid.py
@@ -84,7 +84,7 @@ def draw_absolute_grid(
     h, w, _ = frame.shape
 
     # get absolute points grid
-    points = _get_grid(grid_size, w, h, polar=polar)
+    points = _get_grid(grid_size, w, h, polar=polar).copy()
 
     # transform the points to relative coordinates
     if coord_transformations is None:

--- a/norfair/drawing/draw_points.py
+++ b/norfair/drawing/draw_points.py
@@ -160,20 +160,25 @@ def draw_points(
                     )
 
         if draw_labels or draw_ids or draw_scores:
-            position = d.points[d.live_points].mean(axis=0)
-            position -= radius
-            text = _build_text(
-                d, draw_labels=draw_labels, draw_ids=draw_ids, draw_scores=draw_scores
-            )
+            live = d.points[d.live_points]
+            if len(live) > 0:
+                position = live.mean(axis=0)
+                position -= radius
+                text = _build_text(
+                    d,
+                    draw_labels=draw_labels,
+                    draw_ids=draw_ids,
+                    draw_scores=draw_scores,
+                )
 
-            Drawer.text(
-                frame,
-                text,
-                tuple(position.astype(int)),  # pyrefly: ignore[bad-argument-type]
-                size=text_size,
-                color=obj_text_color,
-                thickness=text_thickness,
-            )
+                Drawer.text(
+                    frame,
+                    text,
+                    tuple(position.astype(int)),  # pyrefly: ignore[bad-argument-type]
+                    size=text_size,
+                    color=obj_text_color,
+                    thickness=text_thickness,
+                )
 
     return frame
 
@@ -222,7 +227,7 @@ def draw_tracked_objects(
     elif id_size is not None:
         text_size_value = int(id_size)
 
-    _draw_points_alias(
+    return _draw_points_alias(
         frame=frame,
         drawables=objects,
         color=selected_color,

--- a/norfair/metrics.py
+++ b/norfair/metrics.py
@@ -74,12 +74,12 @@ class PredictionsTextFile:
         self.frame_number = 1
 
     def update(self, predictions, frame_number=None):
-        if frame_number is None:
-            frame_number = self.frame_number
         """
         Write tracked object information in the output file (for this frame), in the format
         frame_number, id, bb_left, bb_top, bb_width, bb_height, -1, -1, -1, -1
         """
+        if frame_number is None:
+            frame_number = self.frame_number
         for obj in predictions:
             frame_str = str(int(frame_number))
             id_str = str(int(obj.id))

--- a/norfair/tracker.py
+++ b/norfair/tracker.py
@@ -302,7 +302,7 @@ class Tracker:
                 )
 
             # Used just for debugging distance function
-            if distance_matrix.any():
+            if distance_matrix.size > 0:
                 for i, minimum in enumerate(distance_matrix.min(axis=0)):
                     objects[i].current_min_distance = (
                         minimum if minimum < distance_threshold else None

--- a/norfair/video.py
+++ b/norfair/video.py
@@ -270,7 +270,7 @@ class Video:
         if self.input_path is not None:
             file_name = self.input_path.split("/")[-1].split(".")[0]
         else:
-            file_name = "camera_{self.camera}"
+            file_name = f"camera_{self.camera}"
         file_name = f"{file_name}_out.{self.output_extension}"
 
         return os.path.join(self.output_path, file_name)


### PR DESCRIPTION
## Summary
- Fix missing f-string for camera output filename (CR-01)
- Fix `draw_tracked_objects` not returning the frame (CR-02)
- Fix NaN text position when all tracked points are dead (CR-03)
- Fix `lru_cache` on mutable NumPy array in grid drawing (CR-04)
- Fix misplaced docstring in `PredictionsTextFile.update` (CR-05)
- Fix `distance_matrix.any()` incorrectly skipping zero distances (CR-06)

## Test plan
- [x] `uv run pytest -v tests/ --ignore=tests/mot_metrics.py` — all tests pass
- [x] `uv run ruff check .` — no lint errors
- [x] `uv run ruff format --check .` — formatting clean

Part 1 of 6 in the code review fix series.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Fixed distance matrix matching to correctly handle zero-value distances.
  - Fixed output file path generation to properly reflect camera IDs.
  - Improved text rendering efficiency by skipping computation when no live points exist.
  - Protected cached grid data from accidental mutations.

* **Changes**
  - `draw_tracked_objects` now returns the processed frame.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->