### PR TITLE
Fix medium-severity bugs found in code review

### DIFF
--- a/norfair/camera_motion.py
+++ b/norfair/camera_motion.py
@@ -153,7 +153,7 @@ class HomographyTransformation(CoordinatesTransformation):
         points_with_ones = np.hstack((points, ones))
         points_transformed = points_with_ones @ self.homography_matrix.T
         last_column = points_transformed[:, -1]
-        last_column[last_column == 0] = 0.0000001
+        last_column = np.where(last_column == 0, np.finfo(float).eps, last_column)
         points_transformed = points_transformed / last_column.reshape(-1, 1)
         result = points_transformed[:, :2]
         if single_point:
@@ -168,7 +168,7 @@ class HomographyTransformation(CoordinatesTransformation):
         points_with_ones = np.hstack((points, ones))
         points_transformed = points_with_ones @ self.inverse_homography_matrix.T
         last_column = points_transformed[:, -1]
-        last_column[last_column == 0] = 0.0000001
+        last_column = np.where(last_column == 0, np.finfo(float).eps, last_column)
         points_transformed = points_transformed / last_column.reshape(-1, 1)
         result = points_transformed[:, :2]
         if single_point:

--- a/norfair/drawing/color.py
+++ b/norfair/drawing/color.py
@@ -25,14 +25,14 @@ def hex_to_bgr(hex_value: str) -> ColorType:
     ValueError
         if the string is invalid
     """
-    if re.match("#[a-f0-9]{6}$", hex_value):
+    if re.match("#[a-fA-F0-9]{6}$", hex_value):
         return (
             int(hex_value[5:7], 16),
             int(hex_value[3:5], 16),
             int(hex_value[1:3], 16),
         )
 
-    if re.match("#[a-f0-9]{3}$", hex_value):
+    if re.match("#[a-fA-F0-9]{3}$", hex_value):
         return (
             int(hex_value[3] * 2, 16),
             int(hex_value[2] * 2, 16),

--- a/norfair/drawing/draw_boxes.py
+++ b/norfair/drawing/draw_boxes.py
@@ -194,8 +194,8 @@ def draw_tracked_boxes(
     label_size: int | None = None,
     label_width: int | None = None,
 ) -> np.ndarray:
-    "**Deprecated**. Use [`draw_box`][norfair.drawing.draw_boxes.draw_boxes]"
-    warn_once("draw_tracked_boxes is deprecated, use draw_box instead")
+    "**Deprecated**. Use [`draw_boxes`][norfair.drawing.draw_boxes.draw_boxes]"
+    warn_once("draw_tracked_boxes is deprecated, use draw_boxes instead")
     # Determine color - default to "by_id" if border_colors is None
     selected_color: ColorLike = (
         "by_label"

--- a/norfair/drawing/drawer.py
+++ b/norfair/drawing/drawer.py
@@ -365,5 +365,5 @@ class Drawable:
             self.live_points = live_points  # pyrefly: ignore[bad-assignment]
         else:
             raise ValueError(
-                f"Extecting a Detection or a TrackedObject but received {type(obj)}"
+                f"Expecting a Detection or a TrackedObject but received {type(obj)}"
             )

--- a/norfair/drawing/path.py
+++ b/norfair/drawing/path.py
@@ -257,4 +257,11 @@ class AbsolutePaths:
             # pyrefly: ignore[bad-argument-type]
             self.past_points[obj.id].insert(0, points_to_draw)
             self.past_points[obj.id] = self.past_points[obj.id][: self.max_history]
+
+        # Clean up dead objects to prevent memory leak
+        active_ids = {obj.id for obj in tracked_objects}
+        dead_ids = [k for k in self.past_points if k not in active_ids]
+        for k in dead_ids:
+            del self.past_points[k]
+
         return frame

--- a/norfair/metrics.py
+++ b/norfair/metrics.py
@@ -109,6 +109,14 @@ class PredictionsTextFile:
         if self.frame_number > self.length:
             self.text_file.close()
 
+    def close(self):
+        """Close the underlying file handle."""
+        if hasattr(self, "text_file") and self.text_file and not self.text_file.closed:
+            self.text_file.close()
+
+    def __del__(self):
+        self.close()
+
 
 class DetectionFileParser:
     """Get Norfair detections from MOTChallenge text files containing detections"""
@@ -225,14 +233,7 @@ class Accumulators:
                     -1,
                     -1,
                 ]
-                if np.shape(self.matrix_predictions)[0] == 0:
-                    self.matrix_predictions = new_row
-                else:
-                    self.matrix_predictions = (
-                        np.vstack(  # pyrefly: ignore[bad-assignment]
-                            (self.matrix_predictions, new_row)
-                        )
-                    )
+                self.matrix_predictions.append(new_row)
         self.frame_number += 1
         # Advance in progress bar
         try:

--- a/norfair/video.py
+++ b/norfair/video.py
@@ -246,8 +246,8 @@ class Video:
             frame = cv2.resize(
                 frame,
                 (
-                    frame.shape[1] // downsample_ratio,
-                    frame.shape[0] // downsample_ratio,
+                    int(frame.shape[1] / downsample_ratio),
+                    int(frame.shape[0] / downsample_ratio),
                 ),
             )
         cv2.imshow("Output", frame)
@@ -268,7 +268,7 @@ class Video:
             return self.output_path
 
         if self.input_path is not None:
-            file_name = self.input_path.split("/")[-1].split(".")[0]
+            file_name = os.path.splitext(os.path.basename(self.input_path))[0]
         else:
             file_name = f"camera_{self.camera}"
         file_name = f"{file_name}_out.{self.output_extension}"
@@ -280,7 +280,7 @@ class Video:
             return self.output_fourcc
 
         # Default codecs for each extension
-        extension = filename[-3:].lower()
+        extension = os.path.splitext(filename)[1].lstrip(".").lower()
         if extension == "avi":
             return "XVID"
         elif extension == "mp4":


### PR DESCRIPTION
## Summary
- Fix `hex_to_bgr` rejecting uppercase hex color strings (CR-07)
- Fix float dimensions from `downsample_ratio` in video output (CR-08)
- Fix non-portable extension extraction in video output (CR-09)
- Fix non-portable path handling in video output filename (CR-10)
- Fix division-by-zero workaround in homography transformation (CR-11)
- Fix file handle leak in `PredictionsTextFile` (CR-12)
- Fix quadratic array growth in `Accumulators.update` (CR-13)
- Fix typo "Extecting" in `Drawable` error message (CR-14)
- Fix memory leak for destroyed objects in `AbsolutePaths` (CR-15)
- Fix wrong function reference in `draw_tracked_boxes` docstring (CR-16)

## Test plan
- [x] `uv run pytest -v tests/ --ignore=tests/mot_metrics.py` — all tests pass
- [x] `uv run ruff check .` — no lint errors
- [x] `uv run ruff format --check .` — formatting clean

Part 2 of 6 in the code review fix series. Merge after #5.