### PR TITLE
Improve test coverage for untested modules

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,15 @@
 import numpy as np
 import pytest
 
+from norfair.tracker import _TrackedObjectFactory
 from norfair.utils import validate_points
+
+
+@pytest.fixture(autouse=True)
+def reset_global_count():
+    """Reset TrackedObject global count before each test for isolation."""
+    _TrackedObjectFactory.global_count = 0
+    yield
 
 
 @pytest.fixture

--- a/tests/mot_metrics.py
+++ b/tests/mot_metrics.py
@@ -1,17 +1,13 @@
 import os.path
-import sys
-import warnings
 
-# Check for NumPy 2.0+ compatibility
 import numpy as np
+import pytest
 
 if np.__version__.split(".")[0] >= "2":
-    warnings.warn(
-        "MOT metrics tests are not compatible with NumPy 2.0+. "
-        "Skipping these tests. To run MOT metrics tests, use NumPy < 2.0.",
-        stacklevel=1,
+    pytest.skip(
+        "motmetrics incompatible with NumPy 2.x",
+        allow_module_level=True,
     )
-    sys.exit(0)
 
 import pandas as pd
 

--- a/tests/test_distances.py
+++ b/tests/test_distances.py
@@ -175,13 +175,13 @@ def test_iou():
     # invalid bbox
     det = np.array([[0, 0]])
     obj = np.array([[0, 0]])
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         iou.distance_function(det, obj)
 
     # invalid bbox
     det = np.array([[0, 0, 1, 1, 2, 2]])
     obj = np.array([[0, 0, 2, 2]])
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         iou.distance_function(det, obj)
 
 
@@ -323,3 +323,72 @@ def test_scipy_distance(mock_obj, mock_det):
     assert isinstance(dist_matrix, np.ndarray)
     assert dist_matrix.shape == (1, 1)
     assert dist_matrix[0, 0] == 1.0
+
+
+def test_vectorized_distance_with_labels(mock_obj, mock_det):
+    """Test that VectorizedDistance handles labels correctly."""
+
+    def distance_function(cands, objs):
+        return np.full(
+            (len(cands), len(objs)),
+            fill_value=0.5,
+            dtype=np.float32,
+        )
+
+    vd = VectorizedDistance(distance_function)
+
+    det_car = mock_det([[1, 2], [3, 4]], label="car")
+    det_person = mock_det([[5, 6], [7, 8]], label="person")
+    obj_car = mock_obj([[1, 2], [3, 4]], label="car")
+    obj_person = mock_obj([[5, 6], [7, 8]], label="person")
+
+    dist_matrix = vd.get_distances([obj_car, obj_person], [det_car, det_person])
+
+    assert dist_matrix.shape == (2, 2)
+    # Same label should have finite distance
+    assert dist_matrix[0, 0] == 0.5  # car-car
+    assert dist_matrix[1, 1] == 0.5  # person-person
+    # Different labels should be inf
+    assert dist_matrix[0, 1] == np.inf  # car-person
+    assert dist_matrix[1, 0] == np.inf  # person-car
+
+
+def test_iou_multi_box():
+    """Test IoU with multiple boxes (NxM distance matrix)."""
+    from norfair.distances import iou
+
+    candidates = np.array(
+        [
+            [0, 0, 2, 2],
+            [3, 3, 5, 5],
+        ]
+    )
+    objects = np.array(
+        [
+            [0, 0, 2, 2],
+            [1, 1, 3, 3],
+            [3, 3, 5, 5],
+        ]
+    )
+
+    dist = iou(candidates, objects)
+    assert dist.shape == (2, 3)
+    # Perfect match for first candidate with first object
+    np.testing.assert_almost_equal(dist[0, 0], 0.0)
+    # Perfect match for second candidate with third object
+    np.testing.assert_almost_equal(dist[1, 2], 0.0)
+    # No overlap between first candidate and third object
+    np.testing.assert_almost_equal(dist[0, 2], 1.0)
+
+
+def test_scalar_distance_label_mismatch(mock_obj, mock_det):
+    """Test that ScalarDistance warns when some detections have labels and some don't."""
+    fro = ScalarDistance(frobenius)
+
+    det_with_label = mock_det([[1, 2], [3, 4]], label="car")
+    obj_no_label = mock_obj([[1, 2], [3, 4]], label=None)
+
+    dist_matrix = fro.get_distances([obj_no_label], [det_with_label])
+
+    # Should be inf because labels don't match
+    assert dist_matrix[0, 0] == np.inf

--- a/tests/test_drawing.py
+++ b/tests/test_drawing.py
@@ -239,7 +239,7 @@ class TestDrawable:
         np.testing.assert_array_equal(d.live_points, lp)
 
     def test_invalid_type_raises(self):
-        with pytest.raises(ValueError, match="Extecting"):
+        with pytest.raises(ValueError, match="Expecting"):
             Drawable("not a valid object")
 
     def test_detection_live_points_shape(self):
@@ -247,3 +247,24 @@ class TestDrawable:
         d = Drawable(det)
         assert d.live_points.shape == (3,)
         assert d.live_points.dtype == bool
+
+    def test_error_message_typo_fix(self):
+        """Verify the error message says 'Expecting' not 'Extecting'."""
+        with pytest.raises(ValueError, match="Expecting"):
+            Drawable(42)
+
+
+# ---------------------------------------------------------------------------
+# hex_to_bgr uppercase (CR-07 fix verification)
+# ---------------------------------------------------------------------------
+
+
+class TestHexToBgrUppercase:
+    def test_uppercase_hex(self):
+        assert hex_to_bgr("#FF0000") == (0, 0, 255)
+        assert hex_to_bgr("#FFFFFF") == (255, 255, 255)
+        assert hex_to_bgr("#00FF00") == (0, 255, 0)
+
+    def test_mixed_case_hex(self):
+        assert hex_to_bgr("#aAbBcC") == (0xCC, 0xBB, 0xAA)
+        assert hex_to_bgr("#FfFfFf") == (255, 255, 255)

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,0 +1,51 @@
+import numpy as np
+
+from norfair.filter import NoFilter, NoFilterFactory
+
+
+class TestNoFilterFactory:
+    def test_create(self):
+        factory = NoFilterFactory()
+        initial_detection = np.array([[1.0, 2.0], [3.0, 4.0]])
+        f = factory.create_filter(initial_detection)
+        assert isinstance(f, NoFilter)
+        # Check initial state matches detection
+        dim_z = 4  # 2 points * 2 dims
+        np.testing.assert_array_equal(
+            f.x[:dim_z].flatten(), initial_detection.flatten()
+        )
+
+    def test_predict_is_noop(self):
+        factory = NoFilterFactory()
+        initial_detection = np.array([[1.0, 2.0]])
+        f = factory.create_filter(initial_detection)
+        x_before = f.x.copy()
+        f.predict()
+        np.testing.assert_array_equal(f.x, x_before)
+
+    def test_update_replaces_position(self):
+        factory = NoFilterFactory()
+        initial_detection = np.array([[1.0, 2.0]])
+        f = factory.create_filter(initial_detection)
+
+        new_points = np.array([[5.0, 6.0]])
+        f.update(np.expand_dims(new_points.flatten(), 0).T)
+        dim_z = 2
+        np.testing.assert_array_equal(f.x[:dim_z].flatten(), new_points.flatten())
+
+    def test_update_with_partial_H(self):
+        factory = NoFilterFactory()
+        initial_detection = np.array([[1.0, 2.0], [3.0, 4.0]])
+        f = factory.create_filter(initial_detection)
+
+        # Only update first point (mask second point)
+        H_pos = np.diag([1, 1, 0, 0]).astype(float)
+        new_points = np.array([[10.0, 20.0], [30.0, 40.0]])
+        f.update(np.expand_dims(new_points.flatten(), 0).T, H=H_pos)
+
+        # First point should be updated
+        np.testing.assert_almost_equal(f.x[0, 0], 10.0)
+        np.testing.assert_almost_equal(f.x[1, 0], 20.0)
+        # Second point should keep original values
+        np.testing.assert_almost_equal(f.x[2, 0], 3.0)
+        np.testing.assert_almost_equal(f.x[3, 0], 4.0)

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -494,8 +494,91 @@ def test_detection_age_after_merge():
         assert pd.age is not None
 
 
-# TODO tests list:
-#   - detections with different labels
-#   - partial matches where some points are missing
-#   - pointwise_hit_counter_max
-#   - past detections
+def test_label_matching():
+    """Test that detections with different labels are not matched together."""
+    tracker = Tracker(
+        distance_function="euclidean",
+        distance_threshold=100,
+        hit_counter_max=4,
+        initialization_delay=0,
+    )
+
+    # Two detections at same point but different labels
+    det_a = Detection(points=np.array([[1, 1]]), label="car")
+    det_b = Detection(points=np.array([[1, 1]]), label="person")
+    tracked = tracker.update([det_a, det_b])
+    assert len(tracked) == 2
+
+    # Each should maintain its label
+    labels = {obj.label for obj in tracked}
+    assert labels == {"car", "person"}
+
+
+def test_nan_distance_raises():
+    """Test that NaN in distance matrix raises ValueError."""
+
+    def bad_distance(det, obj):
+        return float("nan")
+
+    tracker = Tracker(
+        distance_function=bad_distance,
+        distance_threshold=100,
+        hit_counter_max=4,
+        initialization_delay=0,
+    )
+
+    tracker.update([Detection(points=np.array([[1, 1]]))])
+    with pytest.raises(ValueError, match="nan"):
+        tracker.update([Detection(points=np.array([[1, 1]]))])
+
+
+def test_period_parameter():
+    """Test that the period parameter affects hit counter increments."""
+    tracker = Tracker(
+        distance_function="euclidean",
+        distance_threshold=100,
+        hit_counter_max=20,
+        initialization_delay=0,
+    )
+
+    det = [Detection(points=np.array([[1, 1]]))]
+    tracked = tracker.update(det, period=5)
+    assert len(tracked) == 1
+    # With period=5, hit_counter should be 5 (initial period)
+    assert tracked[0].hit_counter == 5
+
+
+def test_estimate_velocity():
+    """Test that estimate_velocity returns expected shape."""
+    tracker = Tracker(
+        distance_function="euclidean",
+        distance_threshold=100,
+        hit_counter_max=4,
+        initialization_delay=0,
+    )
+
+    tracked = tracker.update([Detection(points=np.array([[1, 1]]))])
+    assert len(tracked) == 1
+    vel = tracked[0].estimate_velocity
+    assert vel.shape == (1, 2)
+
+
+def test_global_id():
+    """Test that global_id is assigned and unique across trackers."""
+    tracker1 = Tracker(
+        distance_function="euclidean",
+        distance_threshold=100,
+        initialization_delay=0,
+    )
+    tracker2 = Tracker(
+        distance_function="euclidean",
+        distance_threshold=100,
+        initialization_delay=0,
+    )
+
+    t1 = tracker1.update([Detection(points=np.array([[1, 1]]))])
+    t2 = tracker2.update([Detection(points=np.array([[2, 2]]))])
+
+    assert t1[0].global_id is not None
+    assert t2[0].global_id is not None
+    assert t1[0].global_id != t2[0].global_id


### PR DESCRIPTION
## Summary
- Add tests for `NoFilterFactory` (create, predict, update, partial H)
- Add tracker tests: label matching, NaN distance, period, velocity, global_id
- Add distance tests: `VectorizedDistance` with labels, iou multi-box, `ScalarDistance` label mismatch
- Add drawing tests: hex uppercase, error message typo fix verification
- Add conftest fixture to reset `global_count` for test isolation
- Fix `mot_metrics.py`: use `pytest.skip` instead of `sys.exit` for NumPy 2.x

## Test plan
- [x] `uv run pytest -v tests/ --ignore=tests/mot_metrics.py` — 77 tests pass (up from 60)
- [x] `uv run ruff check .` — no lint errors
- [x] `uv run ruff format --check .` — formatting clean

Part 5 of 6 in the code review fix series. Merge after #8.