### PR TITLE
Fix typos and placeholder docstrings

### DIFF
--- a/norfair/camera_motion.py
+++ b/norfair/camera_motion.py
@@ -1,4 +1,4 @@
-"Camera motion stimation module."
+"Camera motion estimation module."
 
 import contextlib
 import copy
@@ -355,7 +355,7 @@ class MotionEstimator:
     Examples
     --------
     >>> from norfair import Tracker, Video
-    >>> from norfair.camera_motion MotionEstimator
+    >>> from norfair.camera_motion import MotionEstimator
     >>> video = Video("video.mp4")
     >>> tracker = Tracker(...)
     >>> motion_estimator = MotionEstimator()

--- a/norfair/drawing/color.py
+++ b/norfair/drawing/color.py
@@ -312,7 +312,7 @@ PALETTES = {
 
 class Palette:
     """
-    Class to control the color pallete for drawing.
+    Class to control the color palette for drawing.
 
     Examples
     --------

--- a/norfair/drawing/draw_boxes.py
+++ b/norfair/drawing/draw_boxes.py
@@ -26,7 +26,7 @@ def draw_boxes(
     detections: Sequence["Detection"] | None = None,  # Deprecated
     line_color: ColorLike | None = None,  # Deprecated
     line_width: int | None = None,  # Deprecated
-    label_size: int | None = None,  # Deprecated´
+    label_size: int | None = None,  # Deprecated
     draw_scores: bool = False,
 ) -> np.ndarray:
     """

--- a/norfair/drawing/drawer.py
+++ b/norfair/drawing/drawer.py
@@ -281,7 +281,7 @@ class Drawer:
         gamma: float = 0,
     ) -> np.ndarray:
         """
-        Blend 2 frame as a wheigthted sum.
+        Blend 2 frames as a weighted sum.
 
         Parameters
         ----------

--- a/norfair/drawing/path.py
+++ b/norfair/drawing/path.py
@@ -104,7 +104,7 @@ class Paths:
         for obj in tracked_objects:
             if obj.abs_to_rel is not None:
                 warn_once(
-                    "It seems that your using the Path drawer together with MotionEstimator. This is not fully supported and the results will not be what's expected"
+                    "It seems that you're using the Path drawer together with MotionEstimator. This is not fully supported and the results will not be what's expected"
                 )
 
             if self.color is None:

--- a/norfair/filter.py
+++ b/norfair/filter.py
@@ -142,10 +142,6 @@ class NoFilterFactory(FilterFactory):
     [`OptimizedKalmanFilterFactory`](#optimizedkalmanfilterfactory) class, so this class exists only for
     comparative purposes and it is not advised to use it for tracking on a real application.
 
-    Parameters
-    ----------
-    FilterFactory : _type_
-        _description_
     """
 
     def create_filter(self, initial_detection: np.ndarray):

--- a/norfair/video.py
+++ b/norfair/video.py
@@ -202,7 +202,7 @@ class Video:
         Returns
         -------
         int
-            _description_
+            The key code from ``cv2.waitKey(1)``.
         """
         if self.output_video is None:
             # The user may need to access the output file path on their code
@@ -239,7 +239,7 @@ class Video:
         Returns
         -------
         int
-            _description_
+            The key code from ``cv2.waitKey(1)``.
         """
         # Resize to lower resolution for faster streaming over slow connections
         if downsample_ratio != 1.0:


### PR DESCRIPTION
## Summary
- Fix "stimation" typo in camera_motion module docstring (CR-34)
- Fix missing "import" in MotionEstimator docstring example (CR-35)
- Fix "your" → "you're" in Path drawer warning (CR-36)
- Fix "pallete" → "palette" in Palette docstring (CR-37)
- Fix "wheigthted" → "weighted" in Drawer.alpha_blend docstring (CR-38)
- Remove stray ´ character in draw_boxes signature (CR-39)
- Remove placeholder docstring parameters in FilterPyKalmanFilterFactory (CR-40)
- Fill in placeholder _description_ docstrings in Video methods (CR-41)

## Test plan
- [x] `uv run ruff check .` && `uv run ruff format --check .` — clean
- No behavioral changes, documentation-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Dokumentation

* Verschiedene Dokumentationskorrektionen durchgeführt, einschließlich Behebung von Tippfehlern in Docstrings und Fehlermeldungen
* Aktualisierung von Importbeispielen für korrekte Moduldokumentationen
* Grammatikalische und orthografische Verbesserungen in Beschreibungen und Warnmeldungen

<!-- end of auto-generated comment: release notes by coderabbit.ai -->