### PR TITLE
Improve CI/CD pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --locked --group test
+        run: uv sync --locked --all-extras --group test
 
       - name: Run tests with coverage
         run: uv run pytest tests/ --ignore=tests/mot_metrics.py --cov=norfair --cov-report=term-missing --cov-report=xml
@@ -134,7 +134,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Download a single artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v6
         with:
           name: norfair-dist
           path: ./norfair-dist
@@ -152,7 +152,7 @@ jobs:
   #
   release:
     runs-on: ubuntu-24.04
-    needs: [unit-tests, mot-metrics]
+    needs: [unit-tests, mot-metrics, build, install]
     if: github.event_name == 'release'
     env:
       PYTHON_VERSION: "3.12"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   auto-merge:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Approve PR

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   label:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/labeler@v5
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,9 @@
 name: Lint
 
-on: [pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   linting:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to norfair-enough will be documented in this file.
 
 This fork is based on [tryolabs/norfair](https://github.com/tryolabs/norfair) v2.3.0. Published on PyPI as [`norfair-enough`](https://pypi.org/project/norfair-enough/).
 
+## [Unreleased]
+
+### Fixed
+- Fix missing f-string for camera output filename (`video.py`)
+- Fix `draw_tracked_objects` not returning the frame
+- Fix NaN text position when all tracked points are dead
+- Fix `lru_cache` on mutable NumPy array in grid drawing
+- Fix misplaced docstring in `PredictionsTextFile.update`
+- Fix `distance_matrix.any()` incorrectly skipping zero distances
+- Fix `hex_to_bgr` rejecting uppercase hex color strings
+- Fix float dimensions from `downsample_ratio` in video output
+- Fix non-portable path handling in video output filename
+- Fix file extension extraction in video codec selection
+- Fix division-by-zero workaround in homography transformation
+- Fix file handle leak in `PredictionsTextFile`
+- Fix quadratic array growth in `Accumulators.update`
+- Fix typo "Extecting" in `Drawable` error message
+- Fix memory leak for destroyed objects in `AbsolutePaths`
+- Fix wrong function reference in `draw_tracked_boxes` docstring
+- Fix various typos and placeholder docstrings
+
+### Changed
+- Replace mutable default argument in `Tracker.__init__`
+- Unify logging to use `logging.getLogger(__name__)` across all modules
+- Replace `assert` with `ValueError` for input validation
+- Use `__getattr__` instead of `__getattribute__` in dummy import classes
+- Validate both candidates and objects in `iou` distance function
+- Improve test coverage for `NoFilterFactory`, label matching, and drawing
+- Improve CI pipeline: lint on push, release gates, coverage with extras
+
 ## [2.4.0] - 2025-02-26
 
 ### Breaking Changes


### PR DESCRIPTION
## Summary
- Run lint workflow on push to main, not just pull requests (CR-42)
- Add build and install jobs as release dependencies (CR-43)
- Install all extras for coverage to include optional modules (CR-44)
- Unify Ubuntu runner versions to 24.04 (CR-46)
- Unify download-artifact action versions (CR-47)
- Update CHANGELOG with all code review fixes

## Test plan
- [x] `uv run ruff check .` && `uv run ruff format --check .` — clean
- [ ] Verify CI workflows run correctly after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Versionshinweise

* **Chores**
  * CI/CD-Pipeline aktualisiert mit erweiterten Abhängigkeitsauflösungen und erhöhten Voraussetzungen
  * GitHub Actions Runner-Images auf ubuntu-24.04 aktualisiert
  * Linting-Workflow nun auch bei Pushes auf Main-Branch ausgeführt

* **Bug Fixes**
  * Zahlreiche Fehlerberichtigungen dokumentiert und behoben

<!-- end of auto-generated comment: release notes by coderabbit.ai -->