### PR TITLE
Add context manager support to Video for reliable resource cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This fork is based on [tryolabs/norfair](https://github.com/tryolabs/norfair) v2
 
 ### Changed
 - Protect `TrackedObject.global_id` counter with a lock for thread safety
+- Export all public API symbols (`TrackedObject`, `Distance`, `FilterFactory`, `ColorLike`, camera motion and metrics classes) from the top-level package
 - Replace mutable default argument in `Tracker.__init__`
 - Unify logging to use `logging.getLogger(__name__)` across all modules
 - Replace `assert` with `ValueError` for input validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This fork is based on [tryolabs/norfair](https://github.com/tryolabs/norfair) v2
 - Fix various typos and placeholder docstrings
 
 ### Changed
+- Add context manager support and `close()` method to `Video` for reliable resource cleanup
 - Protect `TrackedObject.global_id` counter with a lock for thread safety
 - Export all public API symbols (`TrackedObject`, `Distance`, `FilterFactory`, `ColorLike`, camera motion and metrics classes) from the top-level package
 - Replace mutable default argument in `Tracker.__init__`

--- a/norfair/__init__.py
+++ b/norfair/__init__.py
@@ -5,14 +5,14 @@ Examples
 --------
 >>> from norfair import Detection, Tracker, Video, draw_tracked_objects
 >>> detector = MyDetector()  # Set up a detector
->>> video = Video(input_path="video.mp4")
 >>> tracker = Tracker(distance_function="euclidean", distance_threshold=50)
->>> for frame in video:
->>>    detections = detector(frame)
->>>    norfair_detections = [Detection(points) for points in detections]
->>>    tracked_objects = tracker.update(detections=norfair_detections)
->>>    draw_tracked_objects(frame, tracked_objects)
->>>    video.write(frame)
+>>> with Video(input_path="video.mp4") as video:
+...     for frame in video:
+...         detections = detector(frame)
+...         norfair_detections = [Detection(points) for points in detections]
+...         tracked_objects = tracker.update(detections=norfair_detections)
+...         draw_tracked_objects(frame, tracked_objects)
+...         video.write(frame)
 """
 
 import importlib.metadata

--- a/norfair/video.py
+++ b/norfair/video.py
@@ -74,8 +74,8 @@ class Video:
     ...         video.write(frame)
 
     The context manager ensures that video resources are released even if the
-    loop is interrupted early.  Iterating without ``with`` still works — resources
-    are released when the iterator is exhausted or garbage-collected.
+    loop is interrupted early. Iterating without ``with`` still works — resources
+    are released when the iterator is exhausted or when ``close()`` is called.
     """
 
     def __init__(

--- a/norfair/video.py
+++ b/norfair/video.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import time
 from typing import TYPE_CHECKING, Any
@@ -187,21 +188,25 @@ class Video:
                 f"[white]Output video file saved to: {self.get_output_file_path()}[/white]"
             )
         self.video_capture.release()
-        cv2.destroyAllWindows()
+        with contextlib.suppress(cv2.error):
+            cv2.destroyAllWindows()
 
     # This is a generator, note the yield keyword below.
     def __iter__(self):
+        if self._closed:
+            raise RuntimeError("Cannot iterate over a closed Video")
         try:
             with self.progress_bar as progress_bar:
                 start = time.time()
 
                 # Iterate over video
                 while True:
-                    self.frame_counter += 1
                     ret, frame = self.video_capture.read()
                     if ret is False or frame is None:
                         break
-                    process_fps = self.frame_counter / (time.time() - start)
+                    self.frame_counter += 1
+                    elapsed = time.time() - start
+                    process_fps = self.frame_counter / elapsed if elapsed > 0 else 0.0
                     progress_bar.update(
                         self.task, advance=1, refresh=True, process_fps=process_fps
                     )

--- a/norfair/video.py
+++ b/norfair/video.py
@@ -67,10 +67,14 @@ class Video:
 
     Examples
     --------
-    >>> video = Video(input_path="video.mp4")
-    >>> for frame in video:
-    >>>     # << Your modifications to the frame would go here >>
-    >>>     video.write(frame)
+    >>> with Video(input_path="video.mp4") as video:
+    ...     for frame in video:
+    ...         # << Your modifications to the frame would go here >>
+    ...         video.write(frame)
+
+    The context manager ensures that video resources are released even if the
+    loop is interrupted early.  Iterating without ``with`` still works — resources
+    are released when the iterator is exhausted or garbage-collected.
     """
 
     def __init__(
@@ -131,6 +135,7 @@ class Video:
         self.input_height = self.video_capture.get(cv2.CAP_PROP_FRAME_HEIGHT)
         self.input_width = self.video_capture.get(cv2.CAP_PROP_FRAME_WIDTH)
         self.frame_counter = 0
+        self._closed = False
 
         # Setup progressbar
         if self.label:
@@ -161,24 +166,21 @@ class Video:
             process_fps=0,
         )
 
-    # This is a generator, note the yield keyword below.
-    def __iter__(self):
-        with self.progress_bar as progress_bar:
-            start = time.time()
+    def __enter__(self):
+        return self
 
-            # Iterate over video
-            while True:
-                self.frame_counter += 1
-                ret, frame = self.video_capture.read()
-                if ret is False or frame is None:
-                    break
-                process_fps = self.frame_counter / (time.time() - start)
-                progress_bar.update(
-                    self.task, advance=1, refresh=True, process_fps=process_fps
-                )
-                yield frame
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False
 
-        # Cleanup
+    def close(self):
+        """Release video resources (VideoCapture, VideoWriter, GUI windows).
+
+        Safe to call multiple times; subsequent calls are no-ops.
+        """
+        if self._closed:
+            return
+        self._closed = True
         if self.output_video is not None:
             self.output_video.release()
             print(
@@ -186,6 +188,26 @@ class Video:
             )
         self.video_capture.release()
         cv2.destroyAllWindows()
+
+    # This is a generator, note the yield keyword below.
+    def __iter__(self):
+        try:
+            with self.progress_bar as progress_bar:
+                start = time.time()
+
+                # Iterate over video
+                while True:
+                    self.frame_counter += 1
+                    ret, frame = self.video_capture.read()
+                    if ret is False or frame is None:
+                        break
+                    process_fps = self.frame_counter / (time.time() - start)
+                    progress_bar.update(
+                        self.task, advance=1, refresh=True, process_fps=process_fps
+                    )
+                    yield frame
+        finally:
+            self.close()
 
     def _fail(self, msg: str):
         raise RuntimeError(msg)


### PR DESCRIPTION
## Summary
- Add `__enter__`/`__exit__` context manager protocol to `Video` class
- Add public `close()` method (idempotent, safe to call multiple times)
- Wrap `__iter__` in `try/finally` so resources are released even on early `break` or exceptions
- Update docstring examples to show recommended `with Video(...) as video:` usage

Previously, `VideoCapture` and `VideoWriter` resources were only released when the iterator was fully exhausted. An early `break` from the frame loop would leak file handles.

## Test plan
- [x] `uv run ruff format --check .` passes
- [x] `uv run ruff check .` passes
- [x] `uv run pytest -v tests/ --ignore=tests/mot_metrics.py` — 76 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Neue Funktionen**
  * Die Video-Klasse unterstützt jetzt die with‑Anweisung für automatische Ressourcenbereinigung.
  * Neue close()-Methode für explizite Freigabe von Videoressourcen.
  * Zusätzliche öffentliche API‑Symbole (z. B. TrackedObject, Distance, FilterFactory, ColorLike sowie Kamera‑Bewegungs- und Metrikklassen) werden jetzt vom Paket exportiert.

* **Dokumentation**
  * Beispiele aktualisiert, um die Nutzung von Video mit der with‑Anweisung und korrektes Aufräumen zu zeigen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->