### PR TITLE
Document Detection mutation behavior in Tracker.update()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This fork is based on [tryolabs/norfair](https://github.com/tryolabs/norfair) v2
 - Fix various typos and placeholder docstrings
 
 ### Changed
+- Document `Detection` mutation behavior in `Tracker.update()` and `Detection` docstrings
 - Protect `TrackedObject.global_id` counter with a lock for thread safety
 - Replace mutable default argument in `Tracker.__init__`
 - Unify logging to use `logging.getLogger(__name__)` across all modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ This fork is based on [tryolabs/norfair](https://github.com/tryolabs/norfair) v2
 - Fix various typos and placeholder docstrings
 
 ### Changed
-- Document `Detection` mutation behavior in `Tracker.update()` and `Detection` docstrings
+- Document `Detection` mutation behavior in `Tracker.update()` (`.absolute_points`, `.age`) and `Detection` docstrings
 - Protect `TrackedObject.global_id` counter with a lock for thread safety
 - Replace mutable default argument in `Tracker.__init__`
 - Unify logging to use `logging.getLogger(__name__)` across all modules

--- a/norfair/tracker.py
+++ b/norfair/tracker.py
@@ -191,6 +191,17 @@ class Tracker:
         -------
         List[TrackedObject]
             The list of active tracked objects.
+
+        Notes
+        -----
+        This method **mutates** the ``Detection`` objects passed in:
+
+        - ``absolute_points`` is overwritten with absolute coordinates when
+          *coord_transformations* is provided.
+        - ``age`` is set to the matched ``TrackedObject``'s age when the
+          detection is stored internally.
+
+        If you need the original detection unchanged, pass a copy.
         """
         if coord_transformations is not None and detections is not None:
             for det in detections:
@@ -806,6 +817,17 @@ class Detection:
         tracked objects with new detections. Label's type must be hashable for drawing purposes.
     embedding : Any, optional
         The embedding for the reid_distance.
+
+    Attributes
+    ----------
+    points : np.ndarray
+        The detection points, validated to shape ``(n_points, n_dimensions)``.
+    absolute_points : np.ndarray
+        Starts as a copy of ``points``. When ``coord_transformations`` is passed
+        to :meth:`Tracker.update`, this is overwritten with absolute coordinates.
+    age : Optional[int]
+        Set by the tracker to the matched ``TrackedObject``'s age when the
+        detection is stored as a past detection.  ``None`` until then.
     """
 
     def __init__(


### PR DESCRIPTION
## Summary
- Add `Notes` section to `Tracker.update()` docstring explaining that input `Detection` objects are mutated (`.absolute_points` and `.age`)
- Add `Attributes` section to `Detection` docstring documenting `.absolute_points` and `.age` lifecycle
- Mark CR-24 as "Won't Fix — By Design" in `CODE_REVIEW.md`

The mutation is intentional upstream design: `absolute_points` provides transformed coordinates to the caller, and `age` is part of the `Detection` API. Documenting this explicitly is the right approach rather than changing behavior.

## Test plan
- [x] `uv run ruff format --check .` passes
- [x] `uv run ruff check .` passes
- [x] `uv run pytest -v tests/ --ignore=tests/mot_metrics.py` — 76 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dokumentation**
  * Dokumentation erweitert: Klarstellung, dass Tracker.update() Detection-Objekte bei Koordinatentransformationen verändern kann (absolute_points, age) und dass eine Kopie das Original bewahrt.
  * Ergänzte Attribute-Beschreibung für Detection (points, absolute_points, age).
  * Entfernte veraltete Hinweisnotiz zur internen Zähler-Synchronisation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->