### PR TITLE
Replace hasattr type dispatch with isinstance in distance functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This fork is based on [tryolabs/norfair](https://github.com/tryolabs/norfair) v2
 - Fix various typos and placeholder docstrings
 
 ### Changed
+- Replace fragile `hasattr` type dispatch with `isinstance` in vectorized distance functions
 - Protect `TrackedObject.global_id` counter with a lock for thread safety
 - Replace mutable default argument in `Tracker.__init__`
 - Unify logging to use `logging.getLogger(__name__)` across all modules

--- a/norfair/distances.py
+++ b/norfair/distances.py
@@ -187,6 +187,8 @@ class VectorizedDistance(Distance):
             dtype=np.float32,
         )
 
+        from .tracker import Detection
+
         object_labels = np.array([o.label for o in objects]).astype(str)
         candidate_labels = np.array([c.label for c in candidates]).astype(str)
 
@@ -203,8 +205,6 @@ class VectorizedDistance(Distance):
                 if str(o.label) == label:
                     stacked_objects.append(o.estimate.ravel())
             stacked_objects = np.stack(stacked_objects)
-
-            from .tracker import Detection
 
             stacked_candidates = []
             for c in candidates:

--- a/norfair/distances.py
+++ b/norfair/distances.py
@@ -204,20 +204,15 @@ class VectorizedDistance(Distance):
                     stacked_objects.append(o.estimate.ravel())
             stacked_objects = np.stack(stacked_objects)
 
+            from .tracker import Detection
+
             stacked_candidates = []
             for c in candidates:
                 if str(c.label) == label:
-                    # Detection objects have 'points', TrackedObject has 'estimate'
-                    # Use hasattr to determine which attribute to access
-                    if hasattr(c, "points"):
-                        # This is a Detection object
-                        c_points = c.points
-                        stacked_candidates.append(c_points.ravel())
+                    if isinstance(c, Detection):
+                        stacked_candidates.append(c.points.ravel())
                     else:
-                        # This is a TrackedObject
-                        # pyrefly: ignore[missing-attribute]
-                        c_estimate = c.estimate
-                        stacked_candidates.append(c_estimate.ravel())
+                        stacked_candidates.append(c.estimate.ravel())
             stacked_candidates = np.stack(stacked_candidates)
 
             # calculate the pairwise distances between objects and candidates with this label

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from norfair.tracker import _TrackedObjectFactory
+from norfair.tracker import Detection, _TrackedObjectFactory
 from norfair.utils import validate_points
 
 
@@ -14,20 +14,16 @@ def reset_global_count():
 
 @pytest.fixture
 def mock_det():
-    class FakeDetection:
-        def __init__(self, points, scores=None, label=None) -> None:
-            if not isinstance(points, np.ndarray):
-                points = np.array(points)
-            self.points = points
+    def _make_detection(points, scores=None, label=None):
+        if not isinstance(points, np.ndarray):
+            points = np.array(points)
+        if scores is not None and not isinstance(scores, np.ndarray):
+            scores = np.array(scores)
+            if scores.ndim == 0 and points.shape[0] > 1:
+                scores = np.full(points.shape[0], scores)
+        return Detection(points=points, scores=scores, label=label)
 
-            if scores is not None and not isinstance(scores, np.ndarray):
-                scores = np.array(scores)
-                if scores.ndim == 0 and points.shape[0] > 1:
-                    scores = np.full(points.shape[0], scores)
-            self.scores = scores
-            self.label = label
-
-    return FakeDetection
+    return _make_detection
 
 
 @pytest.fixture
@@ -37,7 +33,7 @@ def mock_obj(mock_det):
             if not isinstance(points, np.ndarray):
                 points = np.array(points)
 
-            self.estimate = points
+            self.estimate = validate_points(points)
             self.last_detection = mock_det(points, scores=scores)
             self.label = label
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,10 +17,6 @@ def mock_det():
     def _make_detection(points, scores=None, label=None):
         if not isinstance(points, np.ndarray):
             points = np.array(points)
-        if scores is not None and not isinstance(scores, np.ndarray):
-            scores = np.array(scores)
-            if scores.ndim == 0 and points.shape[0] > 1:
-                scores = np.full(points.shape[0], scores)
         return Detection(points=points, scores=scores, label=label)
 
     return _make_detection


### PR DESCRIPTION
## Summary
- Replace fragile `hasattr(c, "points")` check in `VectorizedDistance.get_distances()` with `isinstance(c, Detection)` using a local import to avoid circular dependencies
- Update test fixtures in `conftest.py` to create real `Detection` objects instead of duck-typed `FakeDetection` stubs, ensuring `isinstance` checks work correctly in tests

## Test plan
- [x] `uv run ruff format --check .` passes
- [x] `uv run ruff check .` passes
- [x] `uv run pytest -v tests/ --ignore=tests/mot_metrics.py` — 76 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Typüberprüfung in Distanzberechnungsfunktionen modernisiert. Der Code nutzt nun explizitere Verfahren zur Typidentifikation und ersetzt fragile Mechanismen.

* **Tests**
  * Test-Fixtures überarbeitet zur direkten Verwendung von Standard-Erkennungsobjekten. Validierungslogik für Testdaten wurde vereinheitlicht und standardisiert.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->