### PR TITLE
Optimize greedy matching and vectorized distance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ This fork is based on [tryolabs/norfair](https://github.com/tryolabs/norfair) v2
 - Fix various typos and placeholder docstrings
 
 ### Changed
+- Optimize greedy matching to sort-once instead of iterative argmin (O(nm log nm) vs O(nm min(n,m)))
+- Replace O(n*k) `list.remove()` in tracking loop with single-pass set filter
+- Use precomputed label masks in `VectorizedDistance` instead of redundant string comparisons
 - Replace fragile `hasattr` type dispatch with `isinstance` in vectorized distance functions
 - Protect `TrackedObject.global_id` counter with a lock for thread safety
 - Replace mutable default argument in `Tracker.__init__`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This fork is based on [tryolabs/norfair](https://github.com/tryolabs/norfair) v2
 
 ### Changed
 - Document `Detection` mutation behavior in `Tracker.update()` (`.absolute_points`, `.age`) and `Detection` docstrings
+- Replace fragile `hasattr` type dispatch with `isinstance` in vectorized distance functions
 - Protect `TrackedObject.global_id` counter with a lock for thread safety
 - Replace mutable default argument in `Tracker.__init__`
 - Unify logging to use `logging.getLogger(__name__)` across all modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This fork is based on [tryolabs/norfair](https://github.com/tryolabs/norfair) v2
 - Fix various typos and placeholder docstrings
 
 ### Changed
+- Document `Detection` mutation behavior in `Tracker.update()` (`.absolute_points`, `.age`) and `Detection` docstrings
 - Protect `TrackedObject.global_id` counter with a lock for thread safety
 - Replace mutable default argument in `Tracker.__init__`
 - Unify logging to use `logging.getLogger(__name__)` across all modules

--- a/norfair/distances.py
+++ b/norfair/distances.py
@@ -187,6 +187,8 @@ class VectorizedDistance(Distance):
             dtype=np.float32,
         )
 
+        from .tracker import Detection
+
         object_labels = np.array([o.label for o in objects]).astype(str)
         candidate_labels = np.array([c.label for c in candidates]).astype(str)
 
@@ -207,17 +209,10 @@ class VectorizedDistance(Distance):
             stacked_candidates = []
             for c in candidates:
                 if str(c.label) == label:
-                    # Detection objects have 'points', TrackedObject has 'estimate'
-                    # Use hasattr to determine which attribute to access
-                    if hasattr(c, "points"):
-                        # This is a Detection object
-                        c_points = c.points
-                        stacked_candidates.append(c_points.ravel())
+                    if isinstance(c, Detection):
+                        stacked_candidates.append(c.points.ravel())
                     else:
-                        # This is a TrackedObject
-                        # pyrefly: ignore[missing-attribute]
-                        c_estimate = c.estimate
-                        stacked_candidates.append(c_estimate.ravel())
+                        stacked_candidates.append(c.estimate.ravel())
             stacked_candidates = np.stack(stacked_candidates)
 
             # calculate the pairwise distances between objects and candidates with this label

--- a/norfair/distances.py
+++ b/norfair/distances.py
@@ -200,20 +200,20 @@ class VectorizedDistance(Distance):
             obj_mask = object_labels == label
             cand_mask = candidate_labels == label
 
-            stacked_objects = []
-            for o in objects:
-                if str(o.label) == label:
-                    stacked_objects.append(o.estimate.ravel())
-            stacked_objects = np.stack(stacked_objects)
+            obj_indices = np.where(obj_mask)[0]
+            stacked_objects = np.stack(
+                [objects[i].estimate.ravel() for i in obj_indices]
+            )
 
-            stacked_candidates = []
-            for c in candidates:
-                if str(c.label) == label:
-                    if isinstance(c, Detection):
-                        stacked_candidates.append(c.points.ravel())
-                    else:
-                        stacked_candidates.append(c.estimate.ravel())
-            stacked_candidates = np.stack(stacked_candidates)
+            cand_indices = np.where(cand_mask)[0]
+            stacked_candidates = np.stack(
+                [
+                    candidates[i].points.ravel()
+                    if isinstance(candidates[i], Detection)
+                    else candidates[i].estimate.ravel()
+                    for i in cand_indices
+                ]
+            )
 
             # calculate the pairwise distances between objects and candidates with this label
             # and assign the result to the correct positions inside distance_matrix

--- a/norfair/tracker.py
+++ b/norfair/tracker.py
@@ -1,7 +1,7 @@
 import logging
 import threading
 from collections.abc import Callable, Hashable, Sequence
-from typing import Any
+from typing import Any, overload
 
 import numpy as np
 
@@ -229,7 +229,7 @@ class Tracker:
             self.distance_function,
             self.distance_threshold,
             [o for o in alive_objects if not o.is_initializing],
-            detections,
+            detections or [],
             period,
         )
 
@@ -299,6 +299,26 @@ class Tracker:
             if not o.is_initializing and o.hit_counter_is_positive
         ]
 
+    @overload
+    def _update_objects_in_place(
+        self,
+        distance_function: Distance,
+        distance_threshold: float,
+        objects: Sequence["TrackedObject"],
+        candidates: list["Detection"],
+        period: int,
+    ) -> tuple[list["Detection"], list["TrackedObject"], list["TrackedObject"]]: ...
+
+    @overload
+    def _update_objects_in_place(
+        self,
+        distance_function: Distance,
+        distance_threshold: float,
+        objects: Sequence["TrackedObject"],
+        candidates: list["TrackedObject"] | None,
+        period: int,
+    ) -> tuple[list["TrackedObject"], list["TrackedObject"], list["TrackedObject"]]: ...
+
     def _update_objects_in_place(
         self,
         distance_function: Distance,
@@ -336,6 +356,7 @@ class Tracker:
                     d for i, d in enumerate(objects) if i not in matched_obj_indices
                 ]
                 matched_objects = []
+                candidates_to_remove: set[int] = set()
 
                 # Handle matched people/detections
                 for match_cand_idx, match_obj_idx in zip(
@@ -352,12 +373,20 @@ class Tracker:
                         elif isinstance(matched_candidate, TrackedObject):
                             # Merge new TrackedObject with the old one
                             matched_object.merge(matched_candidate)
-                            # If we are matching TrackedObject instances we want to get rid of the
-                            # already matched candidate to avoid matching it again in future frames
-                            self.tracked_objects.remove(matched_candidate)
+                            candidates_to_remove.add(id(matched_candidate))
                     else:
-                        unmatched_candidates.append(matched_candidate)
+                        unmatched_candidates.append(
+                            matched_candidate  # pyrefly: ignore[bad-argument-type]
+                        )
                         unmatched_objects.append(matched_object)
+
+                # Remove merged TrackedObject candidates in a single pass
+                if candidates_to_remove:
+                    self.tracked_objects = [
+                        o
+                        for o in self.tracked_objects
+                        if id(o) not in candidates_to_remove
+                    ]
             else:
                 unmatched_candidates = list(candidates)
                 matched_objects = []
@@ -372,33 +401,35 @@ class Tracker:
     def match_dets_and_objs(self, distance_matrix: np.ndarray, distance_threshold):
         """Matches detections with tracked_objects from a distance matrix
 
-        I used to match by minimizing the global distances, but found several
-        cases in which this was not optimal. So now I just match by starting
-        with the global minimum distance and matching the det-obj corresponding
-        to that distance, then taking the second minimum, and so on until we
-        reach the distance_threshold.
+        Greedy matching: sort all pairwise distances, then iterate from
+        smallest to largest.  Each detection and object is matched at most
+        once; pairs above ``distance_threshold`` are skipped.
 
-        This avoids the the algorithm getting cute with us and matching things
+        This avoids the algorithm getting cute with us and matching things
         that shouldn't be matching just for the sake of minimizing the global
-        distance, which is what used to happen
+        distance, which is what used to happen with Hungarian-style matching.
         """
-        # NOTE: This implementation is terribly inefficient, but it doesn't
-        #       seem to affect the fps at all.
-        distance_matrix = distance_matrix.copy()
         if distance_matrix.size > 0:
+            n_cols = distance_matrix.shape[1]
+            flat = distance_matrix.ravel()
+            sorted_indices = np.argsort(flat, kind="quicksort")
+
             det_idxs = []
             obj_idxs = []
-            current_min = distance_matrix.min()
+            matched_dets: set[int] = set()
+            matched_objs: set[int] = set()
 
-            while current_min < distance_threshold:
-                flattened_arg_min = distance_matrix.argmin()
-                det_idx = flattened_arg_min // distance_matrix.shape[1]
-                obj_idx = flattened_arg_min % distance_matrix.shape[1]
+            for idx in sorted_indices:
+                if flat[idx] >= distance_threshold:
+                    break
+                det_idx = int(idx // n_cols)
+                obj_idx = int(idx % n_cols)
+                if det_idx in matched_dets or obj_idx in matched_objs:
+                    continue
                 det_idxs.append(det_idx)
                 obj_idxs.append(obj_idx)
-                distance_matrix[det_idx, :] = distance_threshold + 1
-                distance_matrix[:, obj_idx] = distance_threshold + 1
-                current_min = distance_matrix.min()
+                matched_dets.add(det_idx)
+                matched_objs.add(obj_idx)
 
             return det_idxs, obj_idxs
         else:

--- a/norfair/tracker.py
+++ b/norfair/tracker.py
@@ -191,6 +191,17 @@ class Tracker:
         -------
         List[TrackedObject]
             The list of active tracked objects.
+
+        Notes
+        -----
+        This method **mutates** the ``Detection`` objects passed in:
+
+        - ``absolute_points`` is overwritten with absolute coordinates when
+          *coord_transformations* is provided.
+        - ``age`` is set to the matched ``TrackedObject``'s age when the
+          detection is stored internally.
+
+        If you need the original detection unchanged, pass a copy.
         """
         if coord_transformations is not None and detections is not None:
             for det in detections:
@@ -806,6 +817,17 @@ class Detection:
         tracked objects with new detections. Label's type must be hashable for drawing purposes.
     embedding : Any, optional
         The embedding for the reid_distance.
+
+    Attributes
+    ----------
+    points : np.ndarray
+        The detection points, validated to shape ``(n_points, n_dimensions)``.
+    absolute_points : np.ndarray
+        Starts as a copy of ``points``. When ``coord_transformations`` is passed
+        to :meth:`Tracker.update`, this is overwritten with absolute coordinates.
+    age : Optional[int]
+        Set by the tracker to the matched ``TrackedObject``'s age when the
+        detection is stored as a past detection.  ``None`` until then.
     """
 
     def __init__(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from norfair.tracker import _TrackedObjectFactory
+from norfair.tracker import Detection, _TrackedObjectFactory
 from norfair.utils import validate_points
 
 
@@ -14,20 +14,12 @@ def reset_global_count():
 
 @pytest.fixture
 def mock_det():
-    class FakeDetection:
-        def __init__(self, points, scores=None, label=None) -> None:
-            if not isinstance(points, np.ndarray):
-                points = np.array(points)
-            self.points = points
+    def _make_detection(points, scores=None, label=None):
+        if not isinstance(points, np.ndarray):
+            points = np.array(points)
+        return Detection(points=points, scores=scores, label=label)
 
-            if scores is not None and not isinstance(scores, np.ndarray):
-                scores = np.array(scores)
-                if scores.ndim == 0 and points.shape[0] > 1:
-                    scores = np.full(points.shape[0], scores)
-            self.scores = scores
-            self.label = label
-
-    return FakeDetection
+    return _make_detection
 
 
 @pytest.fixture
@@ -37,7 +29,7 @@ def mock_obj(mock_det):
             if not isinstance(points, np.ndarray):
                 points = np.array(points)
 
-            self.estimate = points
+            self.estimate = validate_points(points)
             self.last_detection = mock_det(points, scores=scores)
             self.label = label
 


### PR DESCRIPTION
## Summary
- **CR-28**: Rewrite `match_dets_and_objs` with sort-once (`argsort`) approach — O(nm log nm) instead of O(nm × min(n,m)) iterative argmin
- **CR-29**: Replace O(n×k) `list.remove()` in tracking loop with single-pass set-based collection and filter
- **CR-31**: Use precomputed label masks (`np.where`) in `VectorizedDistance` instead of redundant per-element string comparisons
- Add `@overload` signatures to `_update_objects_in_place` for type-safe return types
- Mark CR-30, CR-32, CR-33 as Won't Fix (By Design)

## Test plan
- [x] All 76 existing tests pass
- [x] mypy, pyrefly, ruff format, ruff check all pass
- [x] Performance changes are algorithmic only — no behavioral change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimierter Abgleichungsalgorithmus für verbesserte Leistung bei der Objektverfolgung
  * Verbesserte Effizienz bei der Kandidatenfilterung durch optimierte Datenverarbeitung
  * Performance-Verbesserungen bei der Distanzberechnung durch vorkompilierte Maskenoptimierung

<!-- end of auto-generated comment: release notes by coderabbit.ai -->