### PR TITLE
docs: add migration guide from tryolabs/norfair (ne-iqw)

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -75,21 +75,31 @@ Additional deprecated parameters on `draw_points`:
 - `detections=...`      → use `drawables=...`
 - `label_size=...`      → use `text_size=...`
 
+Additional deprecated parameters on `draw_boxes`:
+
+- `color_by_label=True` → use `color="by_label"`
+- `detections=...`      → use `drawables=...`
+- `label_size=...`      → use `text_size=...`
+- `random_color=True`   → use `color="random"`
+- `line_color=...`      → use `color=...`
+- `line_width=...`      → use `thickness=...`
+
 See the [Drawing reference][norfair.drawing] for the full current API.
 
 ## Behavior changes
 
-### `Tracker.update()` no longer mutates your `Detection` objects
+### `Tracker.update()` may mutate `Detection` objects -- behavior now documented
 
-In upstream `norfair`, `Tracker.update()` would mutate attributes on the `Detection`
-instances you passed in (for example `detection.absolute_points` and `detection.age`).
-Code that reused the same `Detection` objects after `Tracker.update()` — for drawing,
-logging, or further processing — could observe these mutations.
+In both upstream `norfair` and `norfair-enough`, `Tracker.update()` may mutate attributes
+on the `Detection` instances you pass in (for example `detection.absolute_points` when
+`coord_transformations` is provided, and `detection.age` when detections are mapped to
+tracked objects).
 
-In `norfair-enough`, this mutation behavior is documented explicitly on `Tracker.update()`
-and on `Detection`. If your code relies on reading those attributes *after* calling
-`Tracker.update()`, review it to make sure it still behaves as you expect. In most
-real-world pipelines this change is invisible.
+The difference in `norfair-enough` is that this mutation behavior is now documented
+explicitly in the docstrings for `Tracker.update()` and `Detection`. If your code reuses
+`Detection` objects after calling `Tracker.update()` -- for drawing, logging, or further
+processing -- be aware of these mutations and review your code accordingly. In most
+real-world pipelines this is invisible.
 
 ### Stricter input validation
 
@@ -107,12 +117,12 @@ the buggy behavior you may see different results:
 - `draw_tracked_objects` now returns the frame (previously returned `None`).
 - `distance_matrix.any()` no longer incorrectly skips zero distances during matching.
 - `hex_to_bgr` now accepts uppercase hex color strings.
-- `PredictionsTextFile` no longer leaks file handles.
-- `AbsolutePaths` no longer leaks memory for destroyed objects.
-- `Accumulators.update` no longer grows its arrays quadratically.
-- `Video` output filenames now handle paths and file extensions portably.
-- `Video` now supports the context manager protocol (`with Video(...) as v:`) and exposes
-  a `close()` method for reliable resource cleanup.
+- `PredictionsTextFile` fixes file-handle leaks.
+- `AbsolutePaths` fixes memory leaks for destroyed objects.
+- `Accumulators.update` fixes quadratic array growth.
+- `Video` output filenames now handle paths and file extensions portably; it also supports
+  the context manager protocol (`with Video(...) as v:`) and exposes a `close()` method
+  for reliable resource cleanup.
 - `TrackedObject.global_id` counter is now thread-safe.
 
 For the full list of fixes and changes, see

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,150 @@
+# Migration Guide: tryolabs/norfair → norfair-enough
+
+`norfair-enough` is a maintained fork of [`tryolabs/norfair`](https://github.com/tryolabs/norfair),
+based on upstream v2.3.0. This guide describes what you need to change when moving an existing
+project from the upstream package to `norfair-enough`.
+
+## TL;DR
+
+- Uninstall `norfair`, install `norfair-enough`.
+- The import path stays the same: `from norfair import ...`.
+- Make sure you are on Python 3.10 or newer.
+- Most code continues to work unchanged; a few APIs have been deprecated or behavior has been
+  tightened.
+
+## Installation
+
+Replace the upstream package with the fork:
+
+```bash
+pip uninstall norfair
+pip install norfair-enough
+```
+
+!!! warning "Do not install both packages at the same time"
+    Both `norfair` and `norfair-enough` ship the same top-level Python module (`norfair`).
+    Installing both into the same environment will lead to undefined import behavior.
+    Always uninstall one before installing the other.
+
+Imports do **not** change — `norfair-enough` keeps the original module name:
+
+```python
+from norfair import Detection, Tracker, draw_points
+```
+
+If you install from source, use the fork's repository URL:
+
+```bash
+pip install "git+https://github.com/akator-de/norfair-enough.git@main#egg=norfair-enough"
+```
+
+## Python version
+
+`norfair-enough` requires **Python 3.10 or newer**.
+
+Upstream `norfair` historically supported earlier Python versions (3.8/3.9).
+If your project is still on Python 3.8 or 3.9 you will need to upgrade your interpreter
+before migrating. The fork follows the upstream decision (v2.4.0) to drop older Python
+versions — see [CHANGELOG.md](https://github.com/akator-de/norfair-enough/blob/main/CHANGELOG.md).
+
+The CI matrix for `norfair-enough` covers Python 3.10 through 3.13.
+
+## Dependency changes
+
+- **`filterpy` is no longer a dependency.** The fork ships an internal Kalman filter
+  implementation derived from the original FilterPy `KalmanFilter` class (MIT, Roger R. Labbe Jr.).
+  `FilterPyKalmanFilterFactory` still exists for backwards compatibility but now uses the
+  internal implementation — you can remove `filterpy` from your own requirements.
+- **NumPy 2.x is supported** alongside NumPy 1.23+. No code change required on your side.
+
+## Deprecated drawing APIs
+
+The following drawing helpers are **deprecated** in `norfair-enough` but still work. They now
+emit a deprecation warning on first use. Migrate at your convenience:
+
+| Deprecated                 | Replacement     |
+| -------------------------- | --------------- |
+| `draw_tracked_objects(...)` | `draw_points(...)` |
+| `draw_tracked_boxes(...)`   | `draw_boxes(...)`  |
+
+Both replacements accept tracked objects directly, so most call sites only need a rename.
+
+Additional deprecated parameters on `draw_points`:
+
+- `color_by_label=True` → use `color="by_label"`
+- `detections=...`      → use `drawables=...`
+- `label_size=...`      → use `text_size=...`
+
+See the [Drawing reference][norfair.drawing] for the full current API.
+
+## Behavior changes
+
+### `Tracker.update()` no longer mutates your `Detection` objects
+
+In upstream `norfair`, `Tracker.update()` would mutate attributes on the `Detection`
+instances you passed in (for example `detection.absolute_points` and `detection.age`).
+Code that reused the same `Detection` objects after `Tracker.update()` — for drawing,
+logging, or further processing — could observe these mutations.
+
+In `norfair-enough`, this mutation behavior is documented explicitly on `Tracker.update()`
+and on `Detection`. If your code relies on reading those attributes *after* calling
+`Tracker.update()`, review it to make sure it still behaves as you expect. In most
+real-world pipelines this change is invisible.
+
+### Stricter input validation
+
+- `Tracker` and related APIs now raise `ValueError` for invalid input that previously
+  triggered `assert` statements. If you run Python with `-O`, the previous assertions
+  were silently skipped; now the checks always run.
+- The `iou` distance function validates both candidates and objects (previously only one
+  side was checked).
+
+### Other notable fixes
+
+These are bug fixes relative to upstream v2.3.0. If your code accidentally depended on
+the buggy behavior you may see different results:
+
+- `draw_tracked_objects` now returns the frame (previously returned `None`).
+- `distance_matrix.any()` no longer incorrectly skips zero distances during matching.
+- `hex_to_bgr` now accepts uppercase hex color strings.
+- `PredictionsTextFile` no longer leaks file handles.
+- `AbsolutePaths` no longer leaks memory for destroyed objects.
+- `Accumulators.update` no longer grows its arrays quadratically.
+- `Video` output filenames now handle paths and file extensions portably.
+- `Video` now supports the context manager protocol (`with Video(...) as v:`) and exposes
+  a `close()` method for reliable resource cleanup.
+- `TrackedObject.global_id` counter is now thread-safe.
+
+For the full list of fixes and changes, see
+[CHANGELOG.md](https://github.com/akator-de/norfair-enough/blob/main/CHANGELOG.md).
+
+## Newly exported symbols
+
+The following symbols are now exported directly from the top-level `norfair` package and
+no longer need to be imported from submodules:
+
+- `TrackedObject`
+- `Distance`
+- `FilterFactory`
+- `ColorLike`
+- camera motion classes
+- metrics classes
+
+Old imports continue to work.
+
+## Repository differences
+
+- **Demos**: the fork ships modernized demos under `demos/`. Some have been updated to
+  newer model versions and dependencies.
+- **Tooling**: `norfair-enough` uses [`ruff`](https://docs.astral.sh/ruff/) for linting and
+  `pytest` for tests, with a CI matrix covering Python 3.10–3.13.
+- **Packaging**: published on PyPI as
+  [`norfair-enough`](https://pypi.org/project/norfair-enough/).
+
+## Staying on upstream `tryolabs/norfair`
+
+Upstream `tryolabs/norfair` is no longer actively maintained. If you prefer to stay on it,
+you can continue to install it from
+[its repository](https://github.com/tryolabs/norfair) or PyPI — but be aware that bug fixes
+and new Python/NumPy compatibility work will not flow back. `norfair-enough` exists precisely
+to keep this codebase alive for users who need it.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ extra_javascript:
 nav:
   - Home: index.md
   - Getting Started: getting_started.md
+  - Migration Guide: migration.md
   - Reference:
     - reference/index.md
     - Tracker: reference/tracker.md


### PR DESCRIPTION
## Summary

Adds a new documentation page `docs/migration.md` for users coming from the upstream `tryolabs/norfair` to `norfair-enough`. Covers:

- Install differences (`norfair` → `norfair-enough`)
- Python version bump (3.10+)
- Removed/renamed APIs from PR #27
- Behavioral changes (Detection mutation, etc.)
- Links to CHANGELOG

Also updates `mkdocs.yml` nav to surface the new page after Getting Started.

## Bead
- ne-iqw (parent epic: ne-jz1)

## Verification
`uv run mkdocs build --strict` must pass.

## Notes
Recovered by mayor after polecat session ended before `gt done`. Commit by polecat `garnet`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dokumentation**
  * Neuer Migrationsleitfaden veröffentlicht: Anleitung zum Wechsel auf den maintained Fork, Installationshinweise und Warnung vor gleichzeitiger Installation.
  * Mindestanforderung: Python 3.10+; Kompatibilität mit NumPy 2.x.
  * Abhängigkeitsänderung: externe Filterbibliothek entfernt.
  * Veraltete Zeichenfunktionen benannt und Ersatzfunktionen angegeben.
  * Wichtige Verhaltens- und Fehlerbehebungs-Highlights sowie Hinweise zu Packaging und Demos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->