### PR TITLE
chore: license hygiene — add Akator GmbH copyright + PEP 639 cleanup (ne-4hg)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 BSD 3-Clause License
 
 Copyright (c) 2022, Tryolabs
+Copyright (c) 2026, Akator GmbH and norfair-enough contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -180,6 +180,6 @@ For citations in academic publications, please export your desired citation form
 
 ## License
 
-Copyright © 2022, [Tryolabs](https://tryolabs.com). Released under the [BSD 3-Clause](https://github.com/akator-de/norfair-enough/blob/main/LICENSE).
+Copyright © 2022, [Tryolabs](https://tryolabs.com) and © 2026, Akator GmbH and contributors. Released under the [BSD 3-Clause](https://github.com/akator-de/norfair-enough/blob/main/LICENSE).
 
 This project is a fork of [tryolabs/norfair](https://github.com/tryolabs/norfair).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",


### PR DESCRIPTION
## Summary

Documents the fork's copyright holder in `LICENSE` and `README.md`, and removes the deprecated PyPI license classifier now that SPDX is set in `pyproject.toml`.

## Changes

- `LICENSE`: add a second copyright line for **Akator GmbH** alongside the retained Tryolabs notice
- `README.md`: update License section to credit both copyright holders
- `pyproject.toml`: drop the deprecated `License :: OSI Approved :: BSD License` classifier (SPDX `license = "BSD-3-Clause"` already covers this per PEP 639)

## Why

- **Legal clarity**: The Akator GmbH is the juristic person holding copyright on fork contributions. BSD 3-Clause requires retention of the original Tryolabs notice (unchanged); adding a second line documents the fork's copyright per § 7 UrhG (German copyright automatically attaches to the author/juristic person of contributions).
- **PEP 639**: License classifiers are deprecated when the SPDX string is set.

## Bead
- ne-4hg

## Notes
Recovered by mayor after polecat `jasper` session ended before `gt done`. Original commit was amended to correct the copyright holder from the GitHub org handle `akator-de` to the juristic person `Akator GmbH`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Aktualisierte Urheberrechtsangaben in den Lizenztexten und der Projektbeschreibung (Erweiterung der Jahres- und Inhaberhinweise).
  * Entfernte Lizenzklassifizierung aus den Projektmetadaten (Classifier für BSD-Lizenz gelöscht).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->