### PR TITLE
docs: update README + Getting Started, refresh demo links and deprecated API (ne-6zu)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Norfair was originally built by [Tryolabs](https://tryolabs.com).
 
 ## Examples & demos
 
-We provide several examples of how Norfair can be used to add tracking capabilities to different detectors, and also showcase more advanced features. All demos are available in the upstream repository at [tryolabs/norfair](https://github.com/tryolabs/norfair/tree/master/demos).
+We provide several examples of how Norfair can be used to add tracking capabilities to different detectors, and also showcase more advanced features. All demos are available in the [`demos/`](https://github.com/akator-de/norfair-enough/tree/main/demos) directory of this repository (originally adapted from [tryolabs/norfair](https://github.com/tryolabs/norfair/tree/master/demos)).
 
 > Note: for ease of reproducibility, the demos provide Dockerfiles. Even though Norfair does not need a GPU, the default configuration of most demos requires a GPU to be able to run the detectors. For this, make sure you install [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) so that your GPU can be shared with Docker.
 >
@@ -70,28 +70,28 @@ We provide several examples of how Norfair can be used to add tracking capabilit
 
 Most tracking demos are showcased with vehicles and pedestrians, but the detectors are generally trained with many more classes from the [COCO dataset](https://cocodataset.org/).
 
-1. [YOLOv7](https://github.com/tryolabs/norfair/tree/master/demos/yolov7): tracking object centroids or bounding boxes.
-2. [YOLOv5](https://github.com/tryolabs/norfair/tree/master/demos/yolov5): tracking object centroids or bounding boxes.
-3. [YOLOv4](https://github.com/tryolabs/norfair/tree/master/demos/yolov4): tracking object centroids.
-4. [Detectron2](https://github.com/tryolabs/norfair/tree/master/demos/detectron2): tracking object centroids.
-5. [AlphaPose](https://github.com/tryolabs/norfair/tree/master/demos/alphapose): tracking human keypoints (pose estimation) and inserting Norfair into a complex existing pipeline.
-6. [OpenPose](https://github.com/tryolabs/norfair/tree/master/demos/openpose): tracking human keypoints.
-7. [YOLOPv2](https://github.com/CAIC-AD/YOLOPv2): tracking with a model for traffic object detection, drivable road area segmentation, and lane line detection.
-8. [YOLO-NAS](https://github.com/tryolabs/norfair/tree/master/demos/yolo_nas): tracking object centroids or bounding boxes.
+1. [YOLOv7](https://github.com/akator-de/norfair-enough/tree/main/demos/yolov7): tracking object centroids or bounding boxes.
+2. [YOLOv5](https://github.com/akator-de/norfair-enough/tree/main/demos/yolov5): tracking object centroids or bounding boxes.
+3. [YOLOv4](https://github.com/akator-de/norfair-enough/tree/main/demos/yolov4): tracking object centroids.
+4. [Detectron2](https://github.com/akator-de/norfair-enough/tree/main/demos/detectron2): tracking object centroids.
+5. [AlphaPose](https://github.com/akator-de/norfair-enough/tree/main/demos/alphapose): tracking human keypoints (pose estimation) and inserting Norfair into a complex existing pipeline.
+6. [OpenPose](https://github.com/akator-de/norfair-enough/tree/main/demos/openpose): tracking human keypoints.
+7. [YOLOPv2](https://github.com/akator-de/norfair-enough/tree/main/demos/yolopv2): tracking with a model for traffic object detection, drivable road area segmentation, and lane line detection.
+8. [YOLO-NAS](https://github.com/akator-de/norfair-enough/tree/main/demos/yolo_nas): tracking object centroids or bounding boxes.
 
 ### Advanced features
 
-1. [Speed up pose estimation by extrapolating detections](https://github.com/tryolabs/norfair/tree/master/demos/openpose) using [OpenPose](https://github.com/CMU-Perceptual-Computing-Lab/openpose).
-2. [Track both bounding boxes and human keypoints](https://github.com/tryolabs/norfair/tree/master/demos/keypoints_bounding_boxes) (multi-class), unifying the detections from a YOLO model and OpenPose.
-3. [Re-identification (ReID)](https://github.com/tryolabs/norfair/tree/master/demos/reid) of tracked objects using appearance embeddings. This is a good starting point for scenarios with a lot of occlusion, in which the Kalman filter alone would struggle.
-4. [Accurately track objects even if the camera is moving](https://github.com/tryolabs/norfair/tree/master/demos/camera_motion), by estimating camera motion potentially accounting for pan, tilt, rotation, movement in any direction, and zoom.
-5. [Track points in 3D](https://github.com/tryolabs/norfair/tree/master/demos/3d_track), using [MediaPipe Objectron](https://google.github.io/mediapipe/solutions/objectron.html).
-6. [Tracking of small objects](https://github.com/tryolabs/norfair/tree/master/demos/sahi), using [SAHI: Slicing Aided Hyper Inference](https://github.com/obss/sahi).
+1. [Speed up pose estimation by extrapolating detections](https://github.com/akator-de/norfair-enough/tree/main/demos/openpose) using [OpenPose](https://github.com/CMU-Perceptual-Computing-Lab/openpose).
+2. [Track both bounding boxes and human keypoints](https://github.com/akator-de/norfair-enough/tree/main/demos/keypoints_bounding_boxes) (multi-class), unifying the detections from a YOLO model and OpenPose.
+3. [Re-identification (ReID)](https://github.com/akator-de/norfair-enough/tree/main/demos/reid) of tracked objects using appearance embeddings. This is a good starting point for scenarios with a lot of occlusion, in which the Kalman filter alone would struggle.
+4. [Accurately track objects even if the camera is moving](https://github.com/akator-de/norfair-enough/tree/main/demos/camera_motion), by estimating camera motion potentially accounting for pan, tilt, rotation, movement in any direction, and zoom.
+5. [Track points in 3D](https://github.com/akator-de/norfair-enough/tree/main/demos/3d_track), using [MediaPipe Objectron](https://google.github.io/mediapipe/solutions/objectron.html).
+6. [Tracking of small objects](https://github.com/akator-de/norfair-enough/tree/main/demos/sahi), using [SAHI: Slicing Aided Hyper Inference](https://github.com/obss/sahi).
 
 ### Benchmarking and profiling
 
-1. [Kalman filter and distance function profiling](https://github.com/tryolabs/norfair/tree/master/demos/profiling) using [TRT pose estimator](https://github.com/NVIDIA-AI-IOT/trt_pose).
-2. Computation of [MOT17](https://motchallenge.net/data/MOT17/) scores using [motmetrics4norfair](https://github.com/tryolabs/norfair/tree/master/demos/motmetrics4norfair).
+1. [Kalman filter and distance function profiling](https://github.com/akator-de/norfair-enough/tree/main/demos/profiling) using [TRT pose estimator](https://github.com/NVIDIA-AI-IOT/trt_pose).
+2. Computation of [MOT17](https://motchallenge.net/data/MOT17/) scores using [motmetrics4norfair](https://github.com/akator-de/norfair-enough/tree/main/demos/motmetrics4norfair).
 
 ## How it works
 
@@ -111,7 +111,7 @@ import numpy as np
 from detectron2.config import get_cfg
 from detectron2.engine import DefaultPredictor
 
-from norfair import Detection, Tracker, Video, draw_tracked_objects
+from norfair import Detection, Tracker, Video, draw_points
 
 # Set up Detectron2 object detector
 cfg = get_cfg()
@@ -128,7 +128,7 @@ for frame in video:
     detections = detector(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
     detections = [Detection(p) for p in detections['instances'].pred_boxes.get_centers().cpu().numpy()]
     tracked_objects = tracker.update(detections=detections)
-    draw_tracked_objects(frame, tracked_objects)
+    draw_points(frame, drawables=tracked_objects)
     video.write(frame)
 ```
 
@@ -153,7 +153,7 @@ If you are looking for a tracker, here are some other projects worth noting:
 
 ## Benchmarks
 
-[MOT17](https://motchallenge.net/data/MOT17/) and [MOT20](https://motchallenge.net/data/MOT17/) results obtained using [motmetrics4norfair](https://github.com/tryolabs/norfair/tree/master/demos/motmetrics4norfair) demo script on the `train` split. We used detections obtained with [ByteTrack's](https://github.com/ifzhang/ByteTrack) YOLOX object detection model.
+[MOT17](https://motchallenge.net/data/MOT17/) and [MOT20](https://motchallenge.net/data/MOT17/) results obtained using [motmetrics4norfair](https://github.com/akator-de/norfair-enough/tree/main/demos/motmetrics4norfair) demo script on the `train` split. We used detections obtained with [ByteTrack's](https://github.com/ifzhang/ByteTrack) YOLOX object detection model.
 
 | MOT17 Train |   IDF1 IDP IDR    | Rcll  | Prcn  |  MOTA MOTP  |
 | :---------: | :---------------: | :---: | :---: | :---------: |

--- a/docs/gen_index.py
+++ b/docs/gen_index.py
@@ -12,6 +12,11 @@ with open("README.md") as f:
 content = re.sub(r"\]\(/?docs/", r"](", content)
 # remove "docs" from src fields in html
 content = re.sub(r"src=\"/?docs/", 'src="', content)
+# GitHub and mkdocs slugify headings differently. "Examples & demos" becomes
+# "examples--demos" on GitHub (two dashes around the stripped `&`) but
+# "examples-demos" under mkdocs' default slugify. Rewrite the anchor so the
+# rendered index.md has working in-page links.
+content = re.sub(r"#examples--demos\b", "#examples-demos", content)
 
 # write the index
 with mkdocs_gen_files.open("index.md", "w") as fd:  #

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -7,11 +7,11 @@ Norfair's goal is to easily track multiple objects in videos based on the frame-
 We recommend first deciding and setting up the model and then adding Norfair on top of it.
 Models trained for any form of [object detection](https://paperswithcode.com/task/object-detection) or [keypoint detection](https://paperswithcode.com/task/keypoint-detection) (including [pose estimation](https://paperswithcode.com/task/pose-estimation)) are all supported. You can check some of the integrations we have as examples:
 
-- [Yolov7](https://github.com/tryolabs/norfair/tree/master/demos/yolov7), [Yolov5](https://github.com/tryolabs/norfair/tree/master/demos/yolov5) and [Yolov4](https://github.com/tryolabs/norfair/tree/master/demos/yolov4)
-- [Detectron2](https://github.com/tryolabs/norfair/tree/master/demos/detectron2)
-- [Alphapose](https://github.com/tryolabs/norfair/tree/master/demos/alphapose)
-- [Openpose](https://github.com/tryolabs/norfair/tree/master/demos/openpose)
-- [MMDetection](https://github.com/tryolabs/norfair/tree/master/demos/mmdetection)
+- [Yolov7](https://github.com/akator-de/norfair-enough/tree/main/demos/yolov7), [Yolov5](https://github.com/akator-de/norfair-enough/tree/main/demos/yolov5) and [Yolov4](https://github.com/akator-de/norfair-enough/tree/main/demos/yolov4)
+- [Detectron2](https://github.com/akator-de/norfair-enough/tree/main/demos/detectron2)
+- [Alphapose](https://github.com/akator-de/norfair-enough/tree/main/demos/alphapose)
+- [Openpose](https://github.com/akator-de/norfair-enough/tree/main/demos/openpose)
+- [MMDetection](https://github.com/akator-de/norfair-enough/tree/main/demos/mmdetection)
 
 Any other model trained on one of the supported tasks is also supported and should be easy to integrate with Norfair, regardless of whether it uses Pytorch, TensorFlow, or other.
 
@@ -40,7 +40,7 @@ Check the [Video class][norfair.video.Video] for more info on how to use it.
 Let's dive right into a simple example in the following snippet:
 
 ``` python
-from norfair import Detection, Tracker, Video, draw_tracked_objects
+from norfair import Detection, Tracker, Video, draw_points
 
 detector = MyDetector()  # Set up a detector
 video = Video(input_path="video.mp4")
@@ -50,7 +50,7 @@ for frame in video:
    detections = detector(frame)
    norfair_detections = [Detection(points) for points in detections]
    tracked_objects = tracker.update(detections=norfair_detections)
-   draw_tracked_objects(frame, tracked_objects)
+   draw_points(frame, drawables=tracked_objects)
    video.write(frame)
 ```
 
@@ -83,4 +83,4 @@ After inspecting the detections you might find issues with the tracking, several
 - **Incorrect matches** between Detections and TrackedObjects, a couple of scenarios can cause this:
     - `distance_threshold` is too big so the Tracker matches Detections to TrackedObjects that are simply too far. Lower the threshold until you fix the error, the correct value will depend on the distance function that you're using.
     - Mismatches when objects overlap. In this case, tracking becomes more challenging, usually, the quality of the detection degrades causing one of the objects to be missed or creating a single big detection that includes both objects. On top of the detection issues, the tracker needs to decide which detection should be matched to which TrackedObject which can be error-prone if only considering spatial information. The solution is not easy but incorporating the notion of the appearance similarity based on some kind of embedding to your distance_function can help.
-- Can't **recover** an object **after occlusions**. Use ReID distance, see [this demo](https://github.com/tryolabs/norfair/tree/master/demos/reid) for an example but for real-world use you will need a good ReID model that can provide good embeddings.
+- Can't **recover** an object **after occlusions**. Use ReID distance, see [this demo](https://github.com/akator-de/norfair-enough/tree/main/demos/reid) for an example but for real-world use you will need a good ReID model that can provide good embeddings.

--- a/norfair/distances.py
+++ b/norfair/distances.py
@@ -260,8 +260,8 @@ class ScipyDistance(VectorizedDistance):
     metric : str, optional
         Defines the specific Scipy metric to use to calculate the pairwise distances between
         new candidates and objects.
-
-    Other kwargs are passed through to cdist
+    **kwargs
+        Additional keyword arguments passed through to `scipy.spatial.distance.cdist`.
 
     See Also
     --------

--- a/norfair/drawing/fixed_camera.py
+++ b/norfair/drawing/fixed_camera.py
@@ -12,7 +12,6 @@ class FixedCamera:
     As the camera moves, the smaller frame moves in the opposite direction, stabilizing the objects in it.
 
     Useful for debugging or demoing the camera motion.
-    ![Example GIF](../../videos/camera_stabilization.gif)
 
     !!! Warning
         This only works with [`TranslationTransformation`][norfair.camera_motion.TranslationTransformation],


### PR DESCRIPTION
## Summary

Updates README.md and docs/getting_started.md to reflect the current state of the fork:

- Replace stale `tryolabs/norfair/tree/master/demos/...` links with fork-local `akator-de/norfair-enough/tree/main/demos/...` where demos exist in the fork
- Preserve upstream links only where they belong (fork attribution, history references)
- Modernize the Getting Started code example: use `draw_points`/`draw_boxes` instead of the deprecated `draw_tracked_objects`
- Fix the misleading "All demos are available in the upstream repository" note

## Bead
- ne-6zu (parent epic: ne-jz1 — Docs overhaul)

## Verification
`uv run mkdocs build --strict` must pass.

## Notes
Recovered by mayor after polecat `onyx` session ended before `gt done`. Commit by polecat `onyx`.