### PR TITLE
fix: live_points=True for unmatched tracks (ne-l5q, GH#2)

### DIFF
--- a/norfair/tracker.py
+++ b/norfair/tracker.py
@@ -553,6 +553,13 @@ class TrackedObject:
         self.point_hit_counter: np.ndarray = self.detected_at_least_once_points.astype(
             int
         )
+        # Per-point mask tracking which points were matched in the current frame.
+        # On creation, the initial detection counts as the current-frame match.
+        # tracker_step() clears this mask before each new frame, and hit() sets
+        # it for points that were matched this frame. See GH#2.
+        self._point_matched_in_current_frame: np.ndarray = (
+            self.detected_at_least_once_points.copy()
+        )
         initial_detection.age = self.age
         self.past_detections_length = past_detections_length
         self.past_detections: list[Detection]
@@ -578,6 +585,10 @@ class TrackedObject:
         self.hit_counter -= 1
         self.point_hit_counter -= 1
         self.age += 1
+        # Clear the current-frame match mask. hit() will set entries back to
+        # True for points that get matched this frame; points that remain
+        # unmatched stay False so live_points correctly reports them as dead.
+        self._point_matched_in_current_frame = np.zeros(self.num_points, dtype=bool)
         # Advances the tracker's state
         self.filter.predict()
         self.scores = None
@@ -646,7 +657,14 @@ class TrackedObject:
 
     @property
     def live_points(self):
-        return self.point_hit_counter > 0
+        # A point is "live" only if it was matched to a detection in the
+        # current frame AND its pointwise hit counter is still positive.
+        # Previously this relied solely on `point_hit_counter > 0`, which
+        # produced stale True values: an unmatched track still reported
+        # live_points=True because tracker_step() only decrements the
+        # counter by one per frame, while hit() could have pushed it well
+        # above 1 (GH#2, tryolabs/norfair#328).
+        return (self.point_hit_counter > 0) & self._point_matched_in_current_frame
 
     def hit(self, detection: "Detection", period: int = 1):
         """Update tracked object with a new detection
@@ -699,6 +717,12 @@ class TrackedObject:
             self.point_hit_counter >= self.pointwise_hit_counter_max
         ] = self.pointwise_hit_counter_max
         self.point_hit_counter[self.point_hit_counter < 0] = 0
+        # Record which points were matched in the current frame so that
+        # `live_points` reflects the match state of *this* frame. See GH#2.
+        self._point_matched_in_current_frame = np.logical_or(
+            self._point_matched_in_current_frame,
+            points_over_threshold_mask,
+        )
         H_vel = np.zeros(H_pos.shape)  # But we don't directly measure velocity
         H = np.hstack([H_pos, H_vel])
         self.filter.update(
@@ -775,6 +799,11 @@ class TrackedObject:
         self.reid_hit_counter = None
         self.hit_counter = self.initial_period * 2
         self.point_hit_counter = tracked_object.point_hit_counter
+        # The not-yet-initialized tracked object was just matched this frame,
+        # so adopt its current-frame match mask as well (GH#2).
+        self._point_matched_in_current_frame = (
+            tracked_object._point_matched_in_current_frame
+        )
         self.last_distance = tracked_object.last_distance
         self.current_min_distance = tracked_object.current_min_distance
         self.last_detection = tracked_object.last_detection

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -720,3 +720,83 @@ def test_iou_validates_both_candidates_and_objects():
 
     with pytest.raises(ValueError, match="must be defined as np.array with"):
         iou(invalid_candidates, valid_objects)
+
+
+@pytest.mark.parametrize(
+    "filter_factory", [FilterPyKalmanFilterFactory(), OptimizedKalmanFilterFactory()]
+)
+def test_live_points_false_for_unmatched_track(filter_factory):
+    """Regression test for GH#2 (tryolabs/norfair#328).
+
+    An unmatched track must report ``live_points`` as all ``False``. Before
+    the fix, ``live_points`` was derived solely from ``point_hit_counter > 0``
+    and could remain ``True`` for several frames after the last match because
+    ``tracker_step()`` only decrements the counter by one per frame while
+    ``hit()`` can push it well above 1.
+    """
+    tracker = Tracker(
+        "euclidean",
+        initialization_delay=0,
+        distance_threshold=10,
+        hit_counter_max=10,
+        pointwise_hit_counter_max=5,
+        filter_factory=filter_factory,
+    )
+
+    # Build up point_hit_counter with three matched frames so that a single
+    # unmatched frame cannot pull it back to zero.
+    for _ in range(3):
+        tracked = tracker.update([Detection(points=np.array([[1.0, 1.0]]))])
+        assert len(tracked) == 1
+        assert tracked[0].live_points.all()
+
+    # Unmatched frame: point_hit_counter is still > 0 but live_points must
+    # reflect that the track was not matched in the current frame.
+    tracked = tracker.update()
+    assert len(tracked) == 1
+    obj = tracked[0]
+    assert obj.point_hit_counter[0] > 0, (
+        "precondition for regression: counter must still be positive so the "
+        "bug can manifest"
+    )
+    assert not obj.live_points.any(), (
+        f"unmatched track must have live_points=False, got {obj.live_points}"
+    )
+
+    # Re-match on the next frame: live_points must recover.
+    tracked = tracker.update([Detection(points=np.array([[1.0, 1.0]]))])
+    assert len(tracked) == 1
+    assert tracked[0].live_points.all()
+
+
+@pytest.mark.parametrize(
+    "filter_factory", [FilterPyKalmanFilterFactory(), OptimizedKalmanFilterFactory()]
+)
+def test_live_points_partial_match_with_scores(filter_factory):
+    """``live_points`` must be per-point: only points actually matched this
+    frame should be live, even when the object has multiple keypoints."""
+    tracker = Tracker(
+        "euclidean",
+        initialization_delay=0,
+        distance_threshold=100,
+        hit_counter_max=10,
+        pointwise_hit_counter_max=5,
+        detection_threshold=0.5,
+        filter_factory=filter_factory,
+    )
+
+    points = np.array([[1.0, 1.0], [2.0, 2.0]])
+
+    # Warm up with both points scoring above threshold so both counters climb.
+    for _ in range(3):
+        tracker.update([Detection(points=points, scores=np.array([0.9, 0.9]))])
+
+    # Current frame: only the first point is matched (second drops below
+    # detection_threshold). The second point must be reported as not-live even
+    # though its pointwise hit counter is still positive.
+    tracked = tracker.update([Detection(points=points, scores=np.array([0.9, 0.1]))])
+    assert len(tracked) == 1
+    live = tracked[0].live_points
+    assert live[0]
+    assert not live[1]
+    assert tracked[0].point_hit_counter[1] > 0


### PR DESCRIPTION
Fixes akator-de/norfair-enough#2

Addresses the bug where `live_points=True` incorrectly reflected match state for unmatched tracks.

Bead: ne-l5q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bugfixes**
  * Verbesserte Logik zur Kennzeichnung aktiver Tracking-Punkte: Punkte werden nun nur als aktiv markiert, wenn sie tatsächlich im aktuellen Frame übereinstimmen. Dies führt zu höherer Genauigkeit bei der Verfolgung in Szenarien mit fehlenden oder teilweisen Übereinstimmungen.

* **Tests**
  * Neue Regressions-Tests für das Verhalten von Punkt-Tracking bei fehlenden und partiellen Übereinstimmungen hinzugefügt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->