### PR TITLE
docs: audit and refresh docstrings across norfair/*.py (ne-3av)

### DIFF
--- a/norfair/__init__.py
+++ b/norfair/__init__.py
@@ -1,9 +1,8 @@
-"""
-A customizable lightweight Python library for real-time multi-object tracking.
+"""A customizable lightweight Python library for real-time multi-object tracking.
 
 Examples
 --------
->>> from norfair import Detection, Tracker, Video, draw_tracked_objects
+>>> from norfair import Detection, Tracker, Video, draw_points
 >>> detector = MyDetector()  # Set up a detector
 >>> tracker = Tracker(distance_function="euclidean", distance_threshold=50)
 >>> with Video(input_path="video.mp4") as video:
@@ -11,8 +10,9 @@ Examples
 ...         detections = detector(frame)
 ...         norfair_detections = [Detection(points) for points in detections]
 ...         tracked_objects = tracker.update(detections=norfair_detections)
-...         draw_tracked_objects(frame, tracked_objects)
+...         draw_points(frame, tracked_objects)
 ...         video.write(frame)
+
 """
 
 import importlib.metadata

--- a/norfair/camera_motion.py
+++ b/norfair/camera_motion.py
@@ -1,4 +1,9 @@
-"Camera motion estimation module."
+"""Camera motion estimation module.
+
+Contains the abstract coordinate transformation interfaces, the built-in
+translation and homography implementations, and the :class:`MotionEstimator`
+that ties them to OpenCV's sparse optical flow.
+"""
 
 import contextlib
 import copy
@@ -21,85 +26,96 @@ logger = logging.getLogger(__name__)
 # Abstract interfaces
 #
 class CoordinatesTransformation(ABC):
-    """
-    Abstract class representing a coordinate transformation.
+    """Abstract base class representing a coordinate transformation.
 
-    Detections' and tracked objects' coordinates can be interpreted in 2 reference:
+    Detection and tracked-object coordinates can be interpreted in two
+    reference frames:
 
-    - _Relative_: their position on the current frame, (0, 0) is top left
-    - _Absolute_: their position on an fixed space, (0, 0)
-        is the top left of the first frame of the video.
+    - **Relative** — their position on the current frame, where ``(0, 0)``
+      is the top-left corner.
+    - **Absolute** — their position in a fixed space, where ``(0, 0)`` is
+      the top-left corner of the first frame of the video.
 
-    Therefore, coordinate transformation in this context is a class that can transform
-    coordinates in one reference to another.
+    A ``CoordinatesTransformation`` can map coordinates from one reference
+    to the other.
     """
 
     @abstractmethod
     def abs_to_rel(self, points: np.ndarray) -> np.ndarray:
-        pass
+        """Map absolute-frame points to the current relative frame."""
 
     @abstractmethod
     def rel_to_abs(self, points: np.ndarray) -> np.ndarray:
-        pass
+        """Map relative-frame points to the absolute frame."""
 
 
 class TransformationGetter(ABC):
-    """
-    Abstract class representing a method for finding CoordinatesTransformation between 2 sets of points
+    """Abstract base class for objects that infer a ``CoordinatesTransformation``.
+
+    Subclasses take two point clouds (previous and current frame
+    features) and return a flag indicating whether the reference frame
+    should be reset together with the inferred transformation.
     """
 
     @abstractmethod
     def __call__(
         self, curr_pts: np.ndarray, prev_pts: np.ndarray
     ) -> tuple[bool, CoordinatesTransformation | None]:
-        pass
+        """Return ``(update_reference, transformation)`` for the current pair."""
 
 
 #
 # Translation
 #
 class TranslationTransformation(CoordinatesTransformation):
-    """
-    Coordinate transformation between points using a simple translation
+    """Coordinate transformation using a simple 2D translation.
 
     Parameters
     ----------
     movement_vector : np.ndarray
         The vector representing the translation.
+
     """
 
     def __init__(self, movement_vector):
+        """Store the ``movement_vector`` used for the translation."""
         self.movement_vector = movement_vector
 
     def abs_to_rel(self, points: np.ndarray):
+        """Translate absolute points into the current relative frame."""
         return points + self.movement_vector
 
     def rel_to_abs(self, points: np.ndarray):
+        """Translate relative points back into the absolute frame."""
         return points - self.movement_vector
 
 
 class TranslationTransformationGetter(TransformationGetter):
-    """
-    Calculates TranslationTransformation between points.
+    """Compute a :class:`TranslationTransformation` from a pair of point clouds.
 
-    The camera movement is calculated as the mode of optical flow between the previous reference frame
-    and the current.
+    The camera movement is estimated as the mode of the optical flow
+    between the previous reference frame and the current one.
 
-    Comparing consecutive frames can make differences too small to correctly estimate the translation,
-    for this reason the reference frame is kept fixed as we progress through the video.
-    Eventually, if the transformation is no longer able to match enough points, the reference frame is updated.
+    Comparing consecutive frames can yield differences too small to
+    estimate the translation reliably, so the reference frame is kept
+    fixed as we progress through the video. Once the transformation can
+    no longer match enough points, the reference frame is reset.
 
     Parameters
     ----------
     bin_size : float
-        Before calculatin the mode, optiocal flow is bucketized into bins of this size.
-    proportion_points_used_threshold: float
-        Proportion of points that must be matched, otherwise the reference frame must be updated.
+        Before calculating the mode, optical-flow vectors are bucketized
+        into bins of this size.
+    proportion_points_used_threshold : float
+        Proportion of points that must be matched; if the ratio drops
+        below this value, the reference frame is updated.
+
     """
 
     def __init__(
         self, bin_size: float = 0.2, proportion_points_used_threshold: float = 0.9
     ) -> None:
+        """Store parameters and initialize the running flow accumulator."""
         self.bin_size = bin_size
         self.proportion_points_used_threshold = proportion_points_used_threshold
         self.data = None
@@ -107,6 +123,7 @@ class TranslationTransformationGetter(TransformationGetter):
     def __call__(
         self, curr_pts: np.ndarray, prev_pts: np.ndarray
     ) -> tuple[bool, TranslationTransformation]:
+        """Return the translation that best matches the optical flow."""
         # get flow
         flow = curr_pts - prev_pts
 
@@ -138,20 +155,22 @@ class TranslationTransformationGetter(TransformationGetter):
 # Homography
 #
 class HomographyTransformation(CoordinatesTransformation):
-    """
-    Coordinate transformation beweent points using an homography
+    """Coordinate transformation using a 3×3 homography matrix.
 
     Parameters
     ----------
     homography_matrix : np.ndarray
-        The matrix representing the homography
+        The matrix representing the homography.
+
     """
 
     def __init__(self, homography_matrix: np.ndarray):
+        """Store the homography and pre-compute its inverse."""
         self.homography_matrix = homography_matrix
         self.inverse_homography_matrix = np.linalg.inv(homography_matrix)
 
     def abs_to_rel(self, points: np.ndarray):
+        """Apply the forward homography to map absolute points to relative."""
         single_point = points.ndim == 1
         if single_point:
             points = points.reshape(1, -1)
@@ -167,6 +186,7 @@ class HomographyTransformation(CoordinatesTransformation):
         return result
 
     def rel_to_abs(self, points: np.ndarray):
+        """Apply the inverse homography to map relative points to absolute."""
         single_point = points.ndim == 1
         if single_point:
             points = points.reshape(1, -1)
@@ -183,33 +203,40 @@ class HomographyTransformation(CoordinatesTransformation):
 
 
 class HomographyTransformationGetter(TransformationGetter):
-    """
-    Calculates HomographyTransformation between points.
+    """Compute a :class:`HomographyTransformation` from a pair of point clouds.
 
-    The camera movement is represented as an homography that matches the optical flow between the previous reference frame
-    and the current.
+    The camera movement is represented as a homography that maps the
+    optical flow between the previous reference frame and the current one.
 
-    Comparing consecutive frames can make differences too small to correctly estimate the homography, often resulting in the identity.
-    For this reason the reference frame is kept fixed as we progress through the video.
-    Eventually, if the transformation is no longer able to match enough points, the reference frame is updated.
+    Comparing consecutive frames can make differences too small to
+    estimate the homography reliably, often collapsing to the identity.
+    The reference frame is therefore kept fixed as we progress through
+    the video; once the transformation can no longer match enough points,
+    it is reset.
 
     Parameters
     ----------
-    method : Optional[int], optional
-        One of openCV's method for finding homographies.
-        Valid options are: `[0, cv.RANSAC, cv.LMEDS, cv.RHO]`, by default `cv.RANSAC`
+    method : int, optional
+        One of OpenCV's methods for finding homographies. Valid options
+        are ``[0, cv2.RANSAC, cv2.LMEDS, cv2.RHO]``. Defaults to
+        ``cv2.RANSAC``.
     ransac_reproj_threshold : int, optional
-        Maximum allowed reprojection error to treat a point pair as an inlier. More info in links below.
+        Maximum allowed reprojection error to treat a point pair as an
+        inlier. See the OpenCV docs linked below for details.
     max_iters : int, optional
-        The maximum number of RANSAC iterations.  More info in links below.
+        The maximum number of RANSAC iterations. See the OpenCV docs
+        linked below for details.
     confidence : float, optional
-        Confidence level, must be between 0 and 1. More info in links below.
+        Confidence level, must be between 0 and 1. See the OpenCV docs
+        linked below for details.
     proportion_points_used_threshold : float, optional
-        Proportion of points that must be matched, otherwise the reference frame must be updated.
+        Proportion of points that must be matched; if the ratio drops
+        below this value, the reference frame is updated.
 
     See Also
     --------
-    [opencv.findHomography](https://docs.opencv.org/3.4/d9/d0c/group__calib3d.html#ga4abc2ece9fab9398f2e560d53c8c9780)
+    [`cv2.findHomography`](https://docs.opencv.org/3.4/d9/d0c/group__calib3d.html#ga4abc2ece9fab9398f2e560d53c8c9780)
+
     """
 
     def __init__(
@@ -220,6 +247,7 @@ class HomographyTransformationGetter(TransformationGetter):
         confidence: float = 0.995,
         proportion_points_used_threshold: float = 0.9,
     ) -> None:
+        """Store RANSAC parameters and initialize the running homography."""
         self.data = None
         if method is None:
             method = cv2.RANSAC
@@ -232,6 +260,7 @@ class HomographyTransformationGetter(TransformationGetter):
     def __call__(
         self, curr_pts: np.ndarray, prev_pts: np.ndarray
     ) -> tuple[bool, HomographyTransformation | None]:
+        """Return the homography that best matches the optical flow."""
         if not (
             isinstance(prev_pts, np.ndarray)
             and prev_pts.shape[0] >= 4
@@ -278,12 +307,12 @@ def _calc_optical_flow(
     next_img: np.ndarray,
     prev_pts: np.ndarray,
 ) -> tuple[np.ndarray | None, np.ndarray | None]:
-    """
-    Wrapper for cv2.calcOpticalFlowPyrLK with proper type handling.
+    """Typed wrapper around ``cv2.calcOpticalFlowPyrLK``.
 
-    OpenCV's calcOpticalFlowPyrLK can auto-initialize nextPts when it's empty.
-    We create an empty array of the correct type to satisfy the type checker
-    while maintaining the auto-initialization behavior.
+    OpenCV's ``calcOpticalFlowPyrLK`` can auto-initialize ``nextPts`` when
+    it is empty. We pass an empty array of the correct dtype/shape to
+    satisfy static type checkers while preserving the auto-initialization
+    behavior.
     """
     # Create an empty array for nextPts; OpenCV will auto-initialize it
     next_pts_init: np.ndarray = np.array([], dtype=np.float32).reshape(0, 1, 2)
@@ -303,6 +332,7 @@ def _get_sparse_flow(
     mask: np.ndarray | None = None,
     quality_level: float = 0.01,
 ) -> tuple[np.ndarray, np.ndarray]:
+    """Track a set of corner features between two grayscale frames."""
     if prev_pts is None:
         # get points
         prev_pts_result = cv2.goodFeaturesToTrack(
@@ -332,29 +362,33 @@ def _get_sparse_flow(
 
 
 class MotionEstimator:
-    """
-    Estimator of the motion of the camera.
+    """Camera motion estimator driven by sparse optical flow.
 
-    Uses optical flow to estimate the motion of the camera from frame to frame.
-    The optical flow is calculated on a sample of strong points (corners).
+    Uses OpenCV optical flow on a set of strong corner features to
+    estimate the motion of the camera from frame to frame and feeds the
+    result through a :class:`TransformationGetter` to recover a
+    :class:`CoordinatesTransformation`.
 
     Parameters
     ----------
     max_points : int, optional
-        Maximum amount of points sampled.
-        More points make the estimation process slower but more precise
+        Maximum number of points sampled. More points make the estimation
+        slower but more precise.
     min_distance : int, optional
-        Minimum distance between the sample points.
+        Minimum distance between sampled points.
     block_size : int, optional
-        Size of an average block when finding the corners. More info in links below.
+        Size of the averaging block used when finding corners. See the
+        OpenCV link below for details.
     transformations_getter : TransformationGetter, optional
-        An instance of TransformationGetter. By default [`HomographyTransformationGetter`][norfair.camera_motion.HomographyTransformationGetter]
+        The transformation estimator used on the sampled points. Defaults
+        to
+        [`HomographyTransformationGetter`][norfair.camera_motion.HomographyTransformationGetter].
     draw_flow : bool, optional
-        Draws the optical flow on the frame for debugging.
-    flow_color : Optional[Tuple[int, int, int]], optional
-        Color of the drawing, by default blue.
+        Draw the optical flow on the frame in place, for debugging.
+    flow_color : tuple[int, int, int], optional
+        BGR color for the flow drawing. Defaults to a dark blue.
     quality_level : float, optional
-        Parameter characterizing the minimal accepted quality of image corners.
+        Minimum accepted quality of the image corners.
 
     Examples
     --------
@@ -364,13 +398,16 @@ class MotionEstimator:
     >>> tracker = Tracker(...)
     >>> motion_estimator = MotionEstimator()
     >>> for frame in video:
-    >>>    detections = get_detections(frame)  # runs detector and returns Detections
-    >>>    coord_transformation = motion_estimator.update(frame)
-    >>>    tracked_objects = tracker.update(detections, coord_transformations=coord_transformation)
+    ...     detections = get_detections(frame)
+    ...     coord_transformation = motion_estimator.update(frame)
+    ...     tracked_objects = tracker.update(
+    ...         detections, coord_transformations=coord_transformation
+    ...     )
 
     See Also
     --------
-    For more infor on how the points are sampled: [OpenCV.goodFeaturesToTrack](https://docs.opencv.org/3.4/dd/d1a/group__imgproc__feature.html#ga1d6bb77486c8f92d79c8793ad995d541)
+    [`cv2.goodFeaturesToTrack`](https://docs.opencv.org/3.4/dd/d1a/group__imgproc__feature.html#ga1d6bb77486c8f92d79c8793ad995d541)
+
     """
 
     def __init__(
@@ -383,6 +420,7 @@ class MotionEstimator:
         flow_color: tuple[int, int, int] | None = None,
         quality_level: float = 0.01,
     ):
+        """Initialize sampling parameters and the transformation getter."""
         self.max_points = max_points
         self.min_distance = min_distance
         self.block_size = block_size
@@ -407,31 +445,32 @@ class MotionEstimator:
     def update(
         self, frame: np.ndarray, mask: np.ndarray | None = None
     ) -> CoordinatesTransformation | None:
-        """
-        Estimate camera motion for each frame
+        """Estimate the camera motion for one frame.
 
         Parameters
         ----------
         frame : np.ndarray
-            The frame.
+            The current video frame.
         mask : np.ndarray, optional
-            An optional mask to avoid areas of the frame when sampling the corner.
-            Must be an array of shape `(frame.shape[0], frame.shape[1])`, dtype same as frame,
-            and values in {0, 1}.
+            Optional mask excluding regions from corner sampling. Must
+            have shape ``(frame.shape[0], frame.shape[1])``, match the
+            frame's dtype, and contain values in ``{0, 1}``.
 
-            In general, the estimation will work best when it samples many points from the background;
-            with that intention, this parameters is usefull for masking out the detections/tracked objects,
-            forcing the MotionEstimator ignore the moving objects.
-            Can be used to mask static areas of the image, such as score overlays in sport transmisions or
-            timestamps in security cameras.
+            In general, the estimation works best when many points come
+            from the background, so this parameter is useful for masking
+            out detections or tracked objects and forcing the estimator
+            to ignore moving objects. It can also be used to mask static
+            overlays like sport scoreboards or security-camera
+            timestamps.
 
         Returns
         -------
-        CoordinatesTransformation
-            The CoordinatesTransformation that can transform coordinates on this frame to absolute coordinates
-            or vice versa.
-        """
+        CoordinatesTransformation or None
+            A coordinate transformation that can map coordinates on this
+            frame to absolute coordinates and vice versa, or ``None`` if
+            the transformation could not be recovered.
 
+        """
         self.gray_next = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
         if self.gray_prvs is None:
             self.gray_prvs = self.gray_next

--- a/norfair/camera_motion.py
+++ b/norfair/camera_motion.py
@@ -394,7 +394,7 @@ class MotionEstimator:
     --------
     >>> from norfair import Tracker, Video
     >>> from norfair.camera_motion import MotionEstimator
-    >>> video = Video("video.mp4")
+    >>> video = Video(input_path="video.mp4")
     >>> tracker = Tracker(...)
     >>> motion_estimator = MotionEstimator()
     >>> for frame in video:
@@ -453,8 +453,9 @@ class MotionEstimator:
             The current video frame.
         mask : np.ndarray, optional
             Optional mask excluding regions from corner sampling. Must
-            have shape ``(frame.shape[0], frame.shape[1])``, match the
-            frame's dtype, and contain values in ``{0, 1}``.
+            have shape ``(frame.shape[0], frame.shape[1])``, dtype
+            ``np.uint8``, and contain values ``0`` (ignore) or ``255``
+            (consider), as required by ``cv2.goodFeaturesToTrack``.
 
             In general, the estimation works best when many points come
             from the background, so this parameter is useful for masking

--- a/norfair/distances.py
+++ b/norfair/distances.py
@@ -1,4 +1,4 @@
-"""Predefined distances"""
+"""Predefined distance functions and the :class:`Distance` base class."""
 
 import logging
 from abc import ABC, abstractmethod
@@ -20,10 +20,11 @@ logger = logging.getLogger(__name__)
 
 
 class Distance(ABC):
-    """
-    Abstract class representing a distance.
+    """Abstract base class representing a tracker distance.
 
-    Subclasses must implement the method `get_distances`
+    Subclasses must implement :meth:`get_distances`, which returns a
+    distance matrix between tracked objects and candidates (detections or
+    other tracked objects, when ReID is in use).
     """
 
     @abstractmethod
@@ -32,34 +33,36 @@ class Distance(ABC):
         objects: Sequence["TrackedObject"],
         candidates: Sequence["Candidate"] | None,
     ) -> np.ndarray:
-        """
-        Method that calculates the distances between new candidates and objects.
+        """Return the distance matrix between ``objects`` and ``candidates``.
 
         Parameters
         ----------
         objects : Sequence[TrackedObject]
-            Sequence of [TrackedObject][norfair.tracker.TrackedObject] to be compared with potential [Detection][norfair.tracker.Detection] or [TrackedObject][norfair.tracker.TrackedObject]
-            candidates.
-        candidates : Union[List[Detection], List[TrackedObject]], optional
-            List of candidates ([Detection][norfair.tracker.Detection] or [TrackedObject][norfair.tracker.TrackedObject]) to be compared to [TrackedObject][norfair.tracker.TrackedObject].
+            Sequence of [TrackedObject][norfair.tracker.TrackedObject]
+            instances currently being tracked.
+        candidates : Sequence[Detection or TrackedObject], optional
+            Candidates to be compared against the tracked ``objects``.
+            Detections are used during the normal matching step; tracked
+            objects are used during ReID.
 
         Returns
         -------
         np.ndarray
-            A matrix containing the distances between objects and candidates.
+            A ``(n_candidates, n_objects)`` matrix of distances.
+
         """
 
 
 class ScalarDistance(Distance):
-    """
-    ScalarDistance class represents a distance that is calculated pointwise.
+    """Distance computed pointwise (one pair at a time).
 
     Parameters
     ----------
-    distance_function : Union[Callable[["Detection", "TrackedObject"], float], Callable[["TrackedObject", "TrackedObject"], float]]
-        Distance function used to determine the pointwise distance between new candidates and objects.
-        This function should take 2 input arguments, the first being a `Union[Detection, TrackedObject]`,
-        and the second [TrackedObject][norfair.tracker.TrackedObject]. It has to return a `float` with the distance it calculates.
+    distance_function : Callable
+        Function used to compute the distance between a pair. It must
+        accept two positional arguments — a ``Detection`` or
+        ``TrackedObject`` and a ``TrackedObject`` — and return a ``float``.
+
     """
 
     @overload
@@ -79,8 +82,11 @@ class ScalarDistance(Distance):
         distance_function: Callable[["Detection", "TrackedObject"], float]
         | Callable[["TrackedObject", "TrackedObject"], float],
     ):
-        # Store the function; at runtime both signatures work since the actual types
-        # are compatible (duck typing)
+        """Store the per-pair ``distance_function``.
+
+        The two overloads (detection→object and object→object) are both
+        valid at runtime — Python's duck typing handles the dispatch.
+        """
         self.distance_function: Callable = distance_function
 
     def get_distances(
@@ -88,21 +94,24 @@ class ScalarDistance(Distance):
         objects: Sequence["TrackedObject"],
         candidates: Sequence["Candidate"] | None,
     ) -> np.ndarray:
-        """
-        Method that calculates the distances between new candidates and objects.
+        """Return a distance matrix by calling ``distance_function`` for every pair.
+
+        Pairs with mismatched labels are skipped and their entries left at
+        ``np.inf``.
 
         Parameters
         ----------
         objects : Sequence[TrackedObject]
-            Sequence of [TrackedObject][norfair.tracker.TrackedObject] to be compared with potential [Detection][norfair.tracker.Detection] or [TrackedObject][norfair.tracker.TrackedObject]
-            candidates.
-        candidates : Union[List[Detection], List[TrackedObject]], optional
-            List of candidates ([Detection][norfair.tracker.Detection] or [TrackedObject][norfair.tracker.TrackedObject]) to be compared to [TrackedObject][norfair.tracker.TrackedObject].
+            Tracked objects to compare against ``candidates``.
+        candidates : Sequence[Detection or TrackedObject], optional
+            Candidates. ``None`` or empty sequences return a matrix filled
+            with ``np.inf``.
 
         Returns
         -------
         np.ndarray
-            A matrix containing the distances between objects and candidates.
+            A ``(n_candidates, n_objects)`` matrix of distances.
+
         """
         if not objects or not candidates:
             # Handle None or empty cases
@@ -138,23 +147,27 @@ class ScalarDistance(Distance):
 
 
 class VectorizedDistance(Distance):
-    """
-    VectorizedDistance class represents a distance that is calculated in a vectorized way. This means
-    that instead of going through every pair and explicitly calculating its distance, VectorizedDistance
-    uses the entire vectors to compare to each other in a single operation.
+    """Distance computed in a single vectorized operation.
+
+    Rather than iterating over every pair of candidate and tracked object,
+    ``VectorizedDistance`` stacks their coordinates and hands the whole
+    batch to ``distance_function`` in one call — much faster for large
+    numbers of objects.
 
     Parameters
     ----------
     distance_function : Callable[[np.ndarray, np.ndarray], np.ndarray]
-        Distance function used to determine the distances between new candidates and objects.
-        This function should take 2 input arguments, the first being a `np.ndarray` and the second
-        `np.ndarray`. It has to return a `np.ndarray` with the distance matrix it calculates.
+        Distance function that accepts two 2D arrays ``(candidates,
+        objects)`` and returns a ``(n_candidates, n_objects)`` distance
+        matrix.
+
     """
 
     def __init__(
         self,
         distance_function: Callable[[np.ndarray, np.ndarray], np.ndarray],
     ):
+        """Store the vectorized ``distance_function``."""
         self.distance_function = distance_function
 
     def get_distances(
@@ -162,21 +175,26 @@ class VectorizedDistance(Distance):
         objects: Sequence["TrackedObject"],
         candidates: Sequence["Candidate"] | None,
     ) -> np.ndarray:
-        """
-        Method that calculates the distances between new candidates and objects.
+        """Return the distance matrix computed per label group.
+
+        Objects and candidates are grouped by label; for each label the
+        corresponding sub-block of the distance matrix is filled by
+        ``distance_function`` called on the stacked coordinates. Entries
+        across different labels remain ``np.inf``.
 
         Parameters
         ----------
         objects : Sequence[TrackedObject]
-            Sequence of [TrackedObject][norfair.tracker.TrackedObject] to be compared with potential [Detection][norfair.tracker.Detection] or [TrackedObject][norfair.tracker.TrackedObject]
-            candidates.
-        candidates : Union[List[Detection], List[TrackedObject]], optional
-            List of candidates ([Detection][norfair.tracker.Detection] or [TrackedObject][norfair.tracker.TrackedObject]) to be compared to [TrackedObject][norfair.tracker.TrackedObject].
+            Tracked objects to compare against ``candidates``.
+        candidates : Sequence[Detection or TrackedObject], optional
+            Candidates. ``None`` or empty sequences return a matrix filled
+            with ``np.inf``.
 
         Returns
         -------
         np.ndarray
-            A matrix containing the distances between objects and candidates.
+            A ``(n_candidates, n_objects)`` matrix of distances.
+
         """
         if not objects or not candidates:
             # Handle None or empty cases
@@ -230,30 +248,29 @@ class VectorizedDistance(Distance):
     def _compute_distance(
         self, stacked_candidates: np.ndarray, stacked_objects: np.ndarray
     ) -> np.ndarray:
-        """
-        Method that computes the pairwise distances between new candidates and objects.
-        It is intended to use the entire vectors to compare to each other in a single operation.
+        """Compute the pairwise distance between stacked candidates and objects.
 
         Parameters
         ----------
         stacked_candidates : np.ndarray
-            np.ndarray containing a stack of candidates to be compared with the stacked_objects.
+            Stacked candidate coordinates.
         stacked_objects : np.ndarray
-            np.ndarray containing a stack of objects to be compared with the stacked_objects.
+            Stacked object coordinates.
 
         Returns
         -------
         np.ndarray
-            A matrix containing the distances between objects and candidates.
+            A ``(n_candidates, n_objects)`` matrix of distances.
+
         """
         return self.distance_function(stacked_candidates, stacked_objects)
 
 
 class ScipyDistance(VectorizedDistance):
-    """
-    ScipyDistance class extends VectorizedDistance for the use of Scipy's vectorized distances.
+    """Vectorized distance backed by ``scipy.spatial.distance.cdist``.
 
-    This class uses `scipy.spatial.distance.cdist` to calculate distances between two `np.ndarray`.
+    Uses [`scipy.spatial.distance.cdist`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.cdist.html)
+    to calculate distances between two ``np.ndarray`` batches.
 
     Parameters
     ----------
@@ -261,21 +278,23 @@ class ScipyDistance(VectorizedDistance):
         Defines the specific Scipy metric to use to calculate the pairwise distances between
         new candidates and objects.
     **kwargs
-        Additional keyword arguments passed through to `scipy.spatial.distance.cdist`.
+        Additional keyword arguments forwarded to
+        `scipy.spatial.distance.cdist`.
 
     See Also
     --------
     [`scipy.spatial.distance.cdist`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.cdist.html)
+
     """
 
     def __init__(self, metric: str = "euclidean", **kwargs):
+        """Configure the scipy metric and any extra ``cdist`` keyword arguments."""
         self.metric = metric
         super().__init__(distance_function=partial(cdist, metric=self.metric, **kwargs))
 
 
 def frobenius(detection: "Detection", tracked_object: "TrackedObject") -> float:
-    """
-    Frobernius norm on the difference of the points in detection and the estimates in tracked_object.
+    r"""Frobenius norm of the difference between detection points and tracked-object estimates.
 
     The Frobenius distance and norm are given by:
 
@@ -302,16 +321,16 @@ def frobenius(detection: "Detection", tracked_object: "TrackedObject") -> float:
     See Also
     --------
     [`np.linalg.norm`](https://numpy.org/doc/stable/reference/generated/numpy.linalg.norm.html)
+
     """
     return float(np.linalg.norm(detection.points - tracked_object.estimate))
 
 
 def mean_euclidean(detection: "Detection", tracked_object: "TrackedObject") -> float:
-    """
-    Average euclidean distance between the points in detection and estimates in tracked_object.
+    r"""Average Euclidean distance between detection points and tracked-object estimates.
 
     $$
-    d(a, b) = \\frac{\\sum_{i=0}^N ||a_i - b_i||_2}{N}
+    d(a, b) = \frac{\sum_{i=0}^N ||a_i - b_i||_2}{N}
     $$
 
     Parameters
@@ -319,7 +338,7 @@ def mean_euclidean(detection: "Detection", tracked_object: "TrackedObject") -> f
     detection : Detection
         A detection.
     tracked_object : TrackedObject
-        A tracked object
+        A tracked object.
 
     Returns
     -------
@@ -329,28 +348,26 @@ def mean_euclidean(detection: "Detection", tracked_object: "TrackedObject") -> f
     See Also
     --------
     [`np.linalg.norm`](https://numpy.org/doc/stable/reference/generated/numpy.linalg.norm.html)
+
     """
     return np.linalg.norm(detection.points - tracked_object.estimate, axis=1).mean()
 
 
 def mean_manhattan(detection: "Detection", tracked_object: "TrackedObject") -> float:
-    """
-    Average manhattan distance between the points in detection and the estimates in tracked_object
-
-    Given by:
+    r"""Average Manhattan distance between detection points and tracked-object estimates.
 
     $$
-    d(a, b) = \\frac{\\sum_{i=0}^N ||a_i - b_i||_1}{N}
+    d(a, b) = \frac{\sum_{i=0}^N ||a_i - b_i||_1}{N}
     $$
 
-    Where $||a||_1$ is the manhattan norm.
+    Where $||a||_1$ is the Manhattan norm.
 
     Parameters
     ----------
     detection : Detection
         A detection.
     tracked_object : TrackedObject
-        a tracked object.
+        A tracked object.
 
     Returns
     -------
@@ -360,6 +377,7 @@ def mean_manhattan(detection: "Detection", tracked_object: "TrackedObject") -> f
     See Also
     --------
     [`np.linalg.norm`](https://numpy.org/doc/stable/reference/generated/numpy.linalg.norm.html)
+
     """
     return np.linalg.norm(
         detection.points - tracked_object.estimate, ord=1, axis=1
@@ -367,16 +385,12 @@ def mean_manhattan(detection: "Detection", tracked_object: "TrackedObject") -> f
 
 
 def _boxes_area(boxes: np.ndarray) -> np.ndarray:
-    """
-    Calculate the area of bounding boxes.
-    """
+    """Return the area of each bounding box in ``boxes``."""
     return (boxes[2] - boxes[0]) * (boxes[3] - boxes[1])
 
 
 def _validate_bboxes(bboxes: np.ndarray):
-    """
-    Validate that bounding boxes are well formed.
-    """
+    """Validate that ``bboxes`` is a well-formed ``(N, 4)`` array of boxes."""
     if not (
         isinstance(bboxes, np.ndarray)
         and len(bboxes.shape) == 2
@@ -393,24 +407,28 @@ def _validate_bboxes(bboxes: np.ndarray):
 
 
 def iou(candidates: np.ndarray, objects: np.ndarray) -> np.ndarray:
-    """
-    Calculate IoU between two sets of bounding boxes. Both sets of boxes are expected
-    to be in `[x_min, y_min, x_max, y_max]` format.
+    """Compute ``1 - IoU`` between two sets of bounding boxes.
 
-    Normal IoU is 1 when the boxes are the same and 0 when they don't overlap,
-    to transform that into a distance that makes sense we return `1 - iou`.
+    Both sets of boxes are expected to be in
+    ``[x_min, y_min, x_max, y_max]`` format.
+
+    Normal IoU is ``1`` when the boxes are identical and ``0`` when they
+    don't overlap; to turn this into a distance the function returns
+    ``1 - IoU``.
 
     Parameters
     ----------
-    candidates : numpy.ndarray
-        (N, 4) numpy.ndarray containing candidates bounding boxes.
-    objects : numpy.ndarray
-        (K, 4) numpy.ndarray containing objects bounding boxes.
+    candidates : np.ndarray
+        ``(N, 4)`` array of candidate bounding boxes.
+    objects : np.ndarray
+        ``(K, 4)`` array of object bounding boxes.
 
     Returns
     -------
-    numpy.ndarray
-        (N, K) numpy.ndarray of `1 - iou` between candidates and objects.
+    np.ndarray
+        ``(N, K)`` array of ``1 - IoU`` values between candidates and
+        objects.
+
     """
     _validate_bboxes(candidates)
     _validate_bboxes(objects)
@@ -471,20 +489,28 @@ AVAILABLE_VECTORIZED_DISTANCES = (
 
 
 def get_distance_by_name(name: str) -> Distance:
-    """
-    Select a distance by name.
+    """Return a predefined :class:`Distance` by name.
+
+    Accepts the names of Norfair's built-in scalar and vectorized
+    distances, as well as any metric supported by
+    [`scipy.spatial.distance.cdist`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.cdist.html).
 
     Parameters
     ----------
     name : str
-        A string defining the metric to get.
+        Name of the distance to look up.
 
     Returns
     -------
     Distance
-        The distance object.
-    """
+        A distance object ready to be passed to ``Tracker``.
 
+    Raises
+    ------
+    ValueError
+        If ``name`` is not a known distance.
+
+    """
     distance_function: Distance
     if name in _SCALAR_DISTANCE_FUNCTIONS:
         logger.warning(
@@ -511,28 +537,30 @@ def get_distance_by_name(name: str) -> Distance:
 def create_keypoints_voting_distance(
     keypoint_distance_threshold: float, detection_threshold: float
 ) -> Callable[["Detection", "TrackedObject"], float]:
-    """
-    Construct a keypoint voting distance function configured with the thresholds.
+    """Build a keypoint-voting scalar distance bound to the given thresholds.
 
-    Count how many points in a detection match the with a tracked_object.
-    A match is considered when distance between the points is < `keypoint_distance_threshold`
-    and the score of the last_detection of the tracked_object is > `detection_threshold`.
-    Notice the if multiple points are tracked, the ith point in detection can only match the ith
-    point in the tracked object.
+    The returned distance counts how many points in a detection match the
+    points in a tracked object. A point counts as a match when the
+    distance between it and its peer is below
+    ``keypoint_distance_threshold`` and both detection and tracked-object
+    scores exceed ``detection_threshold``. The ``i``-th point in a
+    detection can only match the ``i``-th point in a tracked object.
 
-    Distance is 1 if no point matches and approximates 0 as more points are matched.
+    The distance is ``1`` when nothing matches and tends towards ``0`` as
+    more points match.
 
     Parameters
     ----------
-    keypoint_distance_threshold: float
-        Points closer than this threshold are considered a match.
-    detection_threshold: float
-        Detections and objects with score lower than this threshold are ignored.
+    keypoint_distance_threshold : float
+        Points closer than this threshold count as a match.
+    detection_threshold : float
+        Points with score at or below this threshold are ignored.
 
     Returns
     -------
     Callable
-        The distance funtion that must be passed to the Tracker.
+        A scalar distance function that can be passed to ``Tracker``.
+
     """
 
     def keypoints_voting_distance(
@@ -554,28 +582,29 @@ def create_keypoints_voting_distance(
 def create_normalized_mean_euclidean_distance(
     height: int, width: int
 ) -> Callable[["Detection", "TrackedObject"], float]:
-    """
-    Construct a normalized mean euclidean distance function configured with the max height and width.
+    """Build a normalized mean Euclidean distance bound to the image size.
 
-    The result distance is bound to [0, 1] where 1 indicates oposite corners of the image.
+    The returned distance is normalized so it lies in ``[0, 1]``, where
+    ``1`` corresponds to opposite corners of the image.
 
     Parameters
     ----------
-    height: int
+    height : int
         Height of the image.
-    width: int
+    width : int
         Width of the image.
 
     Returns
     -------
     Callable
-        The distance funtion that must be passed to the Tracker.
+        A scalar distance function that can be passed to ``Tracker``.
+
     """
 
     def normalized__mean_euclidean_distance(
         detection: "Detection", tracked_object: "TrackedObject"
     ) -> float:
-        """Normalized mean euclidean distance"""
+        """Normalized mean Euclidean distance between detection and tracked object."""
         # calculate distances and normalized it by width and height
         difference = (detection.points - tracked_object.estimate).astype(float)
         difference[:, 0] /= width

--- a/norfair/drawing/__init__.py
+++ b/norfair/drawing/__init__.py
@@ -1,4 +1,4 @@
-"Collection of drawing functions"
+"""Collection of drawing helpers: detections, tracked objects, paths and overlays."""
 
 from .absolute_grid import draw_absolute_grid
 from .color import Color, ColorLike, ColorType, Palette

--- a/norfair/drawing/absolute_grid.py
+++ b/norfair/drawing/absolute_grid.py
@@ -52,7 +52,7 @@ def _get_grid(size, w, h, polar=False):
 
 def draw_absolute_grid(
     frame: np.ndarray,
-    coord_transformations: CoordinatesTransformation,
+    coord_transformations: CoordinatesTransformation | None,
     grid_size: int = 20,
     radius: int = 2,
     thickness: int = 1,
@@ -73,9 +73,11 @@ def draw_absolute_grid(
     ----------
     frame : np.ndarray
         The OpenCV frame to draw on. Modified in place.
-    coord_transformations : CoordinatesTransformation
+    coord_transformations : CoordinatesTransformation or None
         The coordinate transformation as returned by a
         [`MotionEstimator`][norfair.camera_motion.MotionEstimator].
+        If ``None``, no coordinate transformation is applied and the grid
+        points are drawn in their original absolute positions.
     grid_size : int, optional
         Number of grid subdivisions per axis.
     radius : int, optional

--- a/norfair/drawing/absolute_grid.py
+++ b/norfair/drawing/absolute_grid.py
@@ -1,3 +1,5 @@
+"""Draw a debugging grid in absolute coordinates over a video frame."""
+
 from functools import lru_cache
 
 import numpy as np
@@ -10,11 +12,13 @@ from .drawer import Drawer
 
 @lru_cache(maxsize=4)
 def _get_grid(size, w, h, polar=False):
-    """
-    Construct the grid of points.
+    """Build a cached grid of points in absolute coordinates.
 
-    Points are choosen
-    Results are cached since the grid in absolute coordinates doesn't change.
+    The points are sampled so that they lie on the intersection of
+    latitude/longitude lines on a unit sphere centered at the camera,
+    then projected onto the absolute plane and scaled to fit the frame.
+    Results are cached because in absolute coordinates the grid never
+    changes between frames.
     """
     # We need to get points on a semi-sphere of radious 1 centered around (0, 0)
 
@@ -55,31 +59,36 @@ def draw_absolute_grid(
     color: ColorType = Color.black,
     polar: bool = False,
 ):
-    """
-    Draw a grid of points in absolute coordinates.
+    """Draw a grid of points in absolute coordinates onto ``frame``.
 
-    Useful for debugging camera motion.
+    Useful for debugging camera-motion estimation: the grid stays put
+    in world space, so any apparent movement of the points reflects the
+    residual error of the estimated transformation.
 
-    The points are drawn as if the camera were in the center of a sphere and points are drawn in the intersection
-    of latitude and longitude lines over the surface of the sphere.
+    The points are drawn as if the camera sat at the center of a unit
+    sphere, at the intersection of latitude and longitude lines on that
+    sphere's surface.
 
     Parameters
     ----------
     frame : np.ndarray
-        The OpenCV frame to draw on.
+        The OpenCV frame to draw on. Modified in place.
     coord_transformations : CoordinatesTransformation
-        The coordinate transformation as returned by the [`MotionEstimator`][norfair.camera_motion.MotionEstimator]
+        The coordinate transformation as returned by a
+        [`MotionEstimator`][norfair.camera_motion.MotionEstimator].
     grid_size : int, optional
-        How many points to draw.
+        Number of grid subdivisions per axis.
     radius : int, optional
-        Size of each point.
+        Radius (in pixels) of each grid cross.
     thickness : int, optional
-        Thickness of each point
+        Stroke thickness of each grid cross.
     color : ColorType, optional
-        Color of the points.
-    polar : Bool, optional
-        If True, the points on the first frame are drawn as if the camera were pointing to a pole (viewed from the center of the earth).
-        By default, False is used which means the points are drawn as if the camera were pointing to the Equator.
+        BGR color of the grid crosses.
+    polar : bool, optional
+        If ``True``, on the first frame the points are drawn as if the
+        camera were pointing at a pole. When ``False`` (the default),
+        the camera is pointing at the equator.
+
     """
     h, w, _ = frame.shape
 

--- a/norfair/drawing/color.py
+++ b/norfair/drawing/color.py
@@ -1,3 +1,5 @@
+"""Color palette utilities for Norfair drawing helpers."""
+
 import re
 from collections.abc import Hashable, Iterable
 
@@ -8,22 +10,24 @@ ColorLike = ColorType | str
 
 
 def hex_to_bgr(hex_value: str) -> ColorType:
-    """Converts conventional 6 digits hex colors to BGR tuples
+    """Convert a hex color string to a BGR tuple.
 
     Parameters
     ----------
     hex_value : str
-        hex value with leading `#` for instance `"#ff0000"`
+        Hex value with a leading ``#``. Both 6-digit (``"#ff0000"``)
+        and 3-digit (``"#f00"``) shorthand are accepted.
 
     Returns
     -------
-    Tuple[int, int, int]
-        BGR values
+    tuple of int
+        The ``(B, G, R)`` triple corresponding to ``hex_value``.
 
     Raises
     ------
     ValueError
-        if the string is invalid
+        If ``hex_value`` does not match a supported hex color format.
+
     """
     if re.match("#[a-fA-F0-9]{6}$", hex_value):
         return (
@@ -42,11 +46,12 @@ def hex_to_bgr(hex_value: str) -> ColorType:
 
 
 class Color:
-    """
-    Contains predefined colors.
+    """Namespace of predefined BGR color constants.
 
-    Colors are defined as a Tuple of integers between 0 and 255 expressing the values in BGR
-    This is the format opencv uses.
+    Colors are stored as ``(B, G, R)`` tuples of integers in the range
+    ``0-255`` — the format that OpenCV consumes. The set includes the
+    CSS/PIL named colors plus the Seaborn ``tab20`` and ``colorblind``
+    palettes (accessible as ``tab1``..``tab20`` and ``cb1``..``cb10``).
     """
 
     # from PIL.ImageColors.colormap
@@ -234,21 +239,30 @@ class Color:
 
 
 def parse_color(color_like: ColorLike) -> ColorType:
-    """Makes best effort to parse the given value to a Color
+    """Best-effort parse of a ``ColorLike`` value to a ``ColorType``.
 
     Parameters
     ----------
     color_like : ColorLike
-        Can be one of:
+        One of:
 
-        1. a string with the 6 digits hex value (`"#ff0000"`)
-        2. a string with one of the names defined in Colors (`"red"`)
-        3. a BGR tuple (`(0, 0, 255)`)
+        1. A 6-digit hex string (e.g. ``"#ff0000"``).
+        2. The name of one of the predefined colors on :class:`Color`
+           (e.g. ``"red"``).
+        3. A BGR tuple (e.g. ``(0, 0, 255)``).
 
     Returns
     -------
-    Color
-        The BGR tuple.
+    tuple of int
+        The resolved ``(B, G, R)`` triple.
+
+    Raises
+    ------
+    ValueError
+        If ``color_like`` is a malformed hex string.
+    AttributeError
+        If ``color_like`` is an unknown color name.
+
     """
     if isinstance(color_like, str):
         if color_like.startswith("#"):
@@ -317,17 +331,25 @@ PALETTES = {
 
 
 class Palette:
-    """
-    Class to control the color palette for drawing.
+    """Process-wide color palette used by the drawing helpers.
+
+    The palette powers the ``"by_id"`` and ``"by_label"`` color
+    strategies in functions like
+    [`draw_points`][norfair.drawing.draw_points.draw_points] and
+    [`draw_boxes`][norfair.drawing.draw_boxes.draw_boxes].
 
     Examples
     --------
-    Change palette:
-    >>> from norfair import Palette
-    >>> Palette.set("colorblind")
-    >>> # or a custom palette
-    >>> from norfair import Color
-    >>> Palette.set([Color.red, Color.blue, "#ffeeff"])
+    Change the active palette by name::
+
+        >>> from norfair import Palette
+        >>> Palette.set("colorblind")
+
+    Or supply a custom list of colors::
+
+        >>> from norfair import Color, Palette
+        >>> Palette.set([Color.red, Color.blue, "#ffeeff"])
+
     """
 
     _colors = PALETTES["tab10"]
@@ -335,15 +357,23 @@ class Palette:
 
     @classmethod
     def set(cls, palette: str | Iterable[ColorLike]):
-        """
-        Selects a color palette.
+        """Select the active color palette.
 
         Parameters
         ----------
-        palette : Union[str, Iterable[ColorLike]]
-            can be either
-            - the name of one of the predefined palettes `tab10`, `tab20`, or `colorblind`
-            - a list of ColorLike objects that can be parsed by [`parse_color`][norfair.drawing.color.parse_color]
+        palette : str or iterable of ColorLike
+            Either:
+
+            - The name of one of the predefined palettes: ``"tab10"``,
+              ``"tab20"`` or ``"colorblind"``.
+            - An iterable of ``ColorLike`` values that can be parsed by
+              [`parse_color`][norfair.drawing.color.parse_color].
+
+        Raises
+        ------
+        ValueError
+            If ``palette`` is an unknown palette name.
+
         """
         if isinstance(palette, str):
             try:
@@ -361,18 +391,32 @@ class Palette:
 
     @classmethod
     def set_default_color(cls, color: ColorLike):
-        """
-        Selects the default color of `choose_color` when hashable is None.
+        """Set the fallback color used when ``choose_color`` is called with ``None``.
 
         Parameters
         ----------
         color : ColorLike
             The new default color.
+
         """
         cls._default_color = parse_color(color)
 
     @classmethod
     def choose_color(cls, hashable: Hashable) -> ColorType:
+        """Deterministically pick a color for ``hashable`` from the palette.
+
+        Parameters
+        ----------
+        hashable : Hashable or None
+            Any hashable value (typically a tracked-object id or label).
+            When ``None``, the palette's default color is returned.
+
+        Returns
+        -------
+        tuple of int
+            A BGR triple from the active palette.
+
+        """
         if hashable is None:
             return cls._default_color
         return cls._colors[abs(hash(hashable)) % len(cls._colors)]

--- a/norfair/drawing/draw_boxes.py
+++ b/norfair/drawing/draw_boxes.py
@@ -1,3 +1,5 @@
+"""Draw detection / tracked-object bounding boxes onto a video frame."""
+
 from collections.abc import Sequence
 
 import numpy as np
@@ -29,69 +31,67 @@ def draw_boxes(
     label_size: int | None = None,  # Deprecated
     draw_scores: bool = False,
 ) -> np.ndarray:
-    """
-    Draw bounding boxes corresponding to Detections or TrackedObjects.
+    """Draw bounding boxes for ``Detection`` or ``TrackedObject``.
 
     Parameters
     ----------
     frame : np.ndarray
         The OpenCV frame to draw on. Modified in place.
-    drawables : Union[Sequence[Detection], Sequence[TrackedObject]], optional
-        List of objects to draw, Detections and TrackedObjects are accepted.
-        This objects are assumed to contain 2 bi-dimensional points defining
-        the bounding box as `[[x0, y0], [x1, y1]]`.
+    drawables : Sequence[Detection] or Sequence[TrackedObject], optional
+        Objects to draw. Each object is assumed to contain two
+        two-dimensional points defining the bounding box as
+        ``[[x0, y0], [x1, y1]]``.
     color : ColorLike, optional
-        This parameter can take:
+        The color to use. May be:
 
-        1. A color as a tuple of ints describing the BGR `(0, 0, 255)`
-        2. A 6-digit hex string `"#FF0000"`
-        3. One of the defined color names `"red"`
-        4. A string defining the strategy to choose colors from the Palette:
+        1. A BGR int tuple like ``(0, 0, 255)``.
+        2. A 6-digit hex string such as ``"#FF0000"``.
+        3. One of the predefined color names (e.g. ``"red"``).
+        4. A palette strategy — ``"by_id"``, ``"by_label"`` or
+           ``"random"``.
 
-            1. based on the id of the objects `"by_id"`
-            2. based on the label of the objects `"by_label"`
-            3. random choice `"random"`
-
-        If using `by_id` or `by_label` strategy but your objects don't
-        have that field defined (Detections never have ids) the
-        selected color will be the same for all objects (Palette's default Color).
-    thickness : Optional[int], optional
-        Thickness or width of the line.
+        When ``"by_id"`` or ``"by_label"`` is used but the object lacks
+        that field (detections never have ``id``), every object is drawn
+        in the palette's default color.
+    thickness : int, optional
+        Thickness (width) of the box outline.
     random_color : bool, optional
-        **Deprecated**. Set color="random".
+        **Deprecated.** Set ``color="random"`` instead.
     color_by_label : bool, optional
-        **Deprecated**. Set color="by_label".
+        **Deprecated.** Set ``color="by_label"`` instead.
     draw_labels : bool, optional
-        If set to True, the label is added to a title that is drawn on top of the box.
-        If an object doesn't have a label this parameter is ignored.
+        If ``True``, the label is drawn above the box. Ignored when the
+        object has no label.
     draw_scores : bool, optional
-        If set to True, the score is added to a title that is drawn on top of the box.
-        If an object doesn't have a label this parameter is ignored.
-    text_size : Optional[float], optional
-        Size of the title, the value is used as a multiplier of the base size of the font.
-        By default the size is scaled automatically based on the frame size.
+        If ``True``, the detection score is drawn above the box. Ignored
+        when the object has no score.
+    text_size : float, optional
+        Size multiplier for the base font used for the text. By default,
+        the size is scaled automatically based on the frame size.
     draw_ids : bool, optional
-        If set to True, the id is added to a title that is drawn on top of the box.
-        If an object doesn't have an id this parameter is ignored.
-    text_color : Optional[ColorLike], optional
-        Color of the text. By default the same color as the box is used.
-    text_thickness : Optional[int], optional
-        Thickness of the font. By default it's scaled with the `text_size`.
+        If ``True``, the id is drawn above the box. Ignored when the
+        object has no id.
+    text_color : ColorLike, optional
+        Color of the text. Defaults to the same color as the box.
+    text_thickness : int, optional
+        Stroke thickness of the text. By default it scales with
+        ``text_size``.
     draw_box : bool, optional
-        Set to False to hide the box and just draw the text.
+        Set to ``False`` to hide the box and only draw the text.
     detections : Sequence[Detection], optional
-        **Deprecated**. Use drawables.
-    line_color: Optional[ColorLike], optional
-        **Deprecated**. Use color.
-    line_width: Optional[int], optional
-        **Deprecated**. Use thickness.
-    label_size: Optional[int], optional
-        **Deprecated**. Use text_size.
+        **Deprecated.** Use ``drawables``.
+    line_color : ColorLike, optional
+        **Deprecated.** Use ``color``.
+    line_width : int, optional
+        **Deprecated.** Use ``thickness``.
+    label_size : int, optional
+        **Deprecated.** Use ``text_size``.
 
     Returns
     -------
     np.ndarray
-        The resulting frame.
+        The ``frame`` passed in (drawn on in place).
+
     """
     #
     # handle deprecated parameters
@@ -194,7 +194,45 @@ def draw_tracked_boxes(
     label_size: int | None = None,
     label_width: int | None = None,
 ) -> np.ndarray:
-    "**Deprecated**. Use [`draw_boxes`][norfair.drawing.draw_boxes.draw_boxes]"
+    """Draw tracked-object bounding boxes onto ``frame``.
+
+    .. deprecated::
+        Use :func:`draw_boxes` instead. This function is kept for
+        backward compatibility and forwards its arguments to
+        :func:`draw_boxes`.
+
+    Parameters
+    ----------
+    frame : np.ndarray
+        The OpenCV frame to draw on. Modified in place.
+    objects : Sequence[TrackedObject]
+        The tracked objects to draw.
+    border_colors : tuple of int, optional
+        BGR border color. Ignored if ``color_by_label`` is ``True``.
+    border_width : int, optional
+        Thickness of the border line.
+    id_size : int, optional
+        Size of the id text. Set to ``0`` to disable id rendering.
+    id_thickness : int, optional
+        Stroke thickness of the id text.
+    draw_box : bool, optional
+        Set to ``False`` to hide the box and only draw the text.
+    color_by_label : bool, optional
+        If ``True``, color objects by label instead of by a fixed
+        ``border_colors``.
+    draw_labels : bool, optional
+        If ``True``, draw the label above the box.
+    label_size : int, optional
+        Size of the label text.
+    label_width : int, optional
+        Stroke thickness of the label text.
+
+    Returns
+    -------
+    np.ndarray
+        The ``frame`` passed in (drawn on in place).
+
+    """
     warn_once("draw_tracked_boxes is deprecated, use draw_boxes instead")
     # Determine color - default to "by_id" if border_colors is None
     selected_color: ColorLike = (

--- a/norfair/drawing/draw_points.py
+++ b/norfair/drawing/draw_points.py
@@ -1,3 +1,5 @@
+"""Draw detection / tracked-object points onto a video frame."""
+
 from collections.abc import Sequence
 
 import numpy as np
@@ -28,69 +30,69 @@ def draw_points(
     label_size: int | None = None,  # deprecated
     draw_scores: bool = False,
 ) -> np.ndarray:
-    """
-    Draw the points included in a list of Detections or TrackedObjects.
+    """Draw the points of a list of ``Detection`` or ``TrackedObject``.
 
     Parameters
     ----------
     frame : np.ndarray
         The OpenCV frame to draw on. Modified in place.
-    drawables : Union[Sequence[Detection], Sequence[TrackedObject]], optional
-        List of objects to draw, Detections and TrackedObjects are accepted.
-    radius : Optional[int], optional
-        Radius of the circles representing each point.
-        By default a sensible value is picked considering the frame size.
-    thickness : Optional[int], optional
-        Thickness or width of the line.
+    drawables : Sequence[Detection] or Sequence[TrackedObject], optional
+        Objects to draw. Both ``Detection`` and ``TrackedObject`` are
+        accepted.
+    radius : int, optional
+        Radius of the circles representing each point. By default a
+        sensible value is picked based on the frame size.
+    thickness : int, optional
+        Thickness of the stroke. ``-1`` (the default) produces filled
+        circles.
     color : ColorLike, optional
-        This parameter can take:
+        The color to use. May be:
 
-        1. A color as a tuple of ints describing the BGR `(0, 0, 255)`
-        2. A 6-digit hex string `"#FF0000"`
-        3. One of the defined color names `"red"`
-        4. A string defining the strategy to choose colors from the Palette:
+        1. A BGR int tuple like ``(0, 0, 255)``.
+        2. A 6-digit hex string such as ``"#FF0000"``.
+        3. One of the predefined color names (e.g. ``"red"``).
+        4. A palette strategy — ``"by_id"``, ``"by_label"`` or
+           ``"random"``.
 
-            1. based on the id of the objects `"by_id"`
-            2. based on the label of the objects `"by_label"`
-            3. random choice `"random"`
-
-        If using `by_id` or `by_label` strategy but your objects don't
-        have that field defined (Detections never have ids) the
-        selected color will be the same for all objects (Palette's default Color).
+        When ``"by_id"`` or ``"by_label"`` is used but the object lacks
+        that field (detections never have ``id``), every object is drawn
+        in the palette's default color.
     color_by_label : bool, optional
-        **Deprecated**. set `color="by_label"`.
+        **Deprecated.** Set ``color="by_label"`` instead.
     draw_labels : bool, optional
-        If set to True, the label is added to a title that is drawn on top of the box.
-        If an object doesn't have a label this parameter is ignored.
+        If ``True``, the label is drawn above the points. Ignored when
+        the object has no label.
     draw_scores : bool, optional
-        If set to True, the score is added to a title that is drawn on top of the box.
-        If an object doesn't have a label this parameter is ignored.
-    text_size : Optional[int], optional
-        Size of the title, the value is used as a multiplier of the base size of the font.
-        By default the size is scaled automatically based on the frame size.
+        If ``True``, the detection score is drawn above the points.
+        Ignored when the object has no score.
+    text_size : int, optional
+        Size multiplier for the base font used for the text. By default,
+        the size is scaled automatically based on the frame size.
     draw_ids : bool, optional
-        If set to True, the id is added to a title that is drawn on top of the box.
-        If an object doesn't have an id this parameter is ignored.
+        If ``True``, the id is drawn above the points. Ignored when the
+        object has no id.
     draw_points : bool, optional
-        Set to False to hide the points and just draw the text.
-    text_thickness : Optional[int], optional
-        Thickness of the font. By default it's scaled with the `text_size`.
-    text_color : Optional[ColorLike], optional
-        Color of the text. By default the same color as the box is used.
+        Set to ``False`` to hide the points and only draw the text.
+    text_thickness : int, optional
+        Stroke thickness of the text. By default it scales with
+        ``text_size``.
+    text_color : ColorLike, optional
+        Color of the text. Defaults to the object's color.
     hide_dead_points : bool, optional
-        Set this param to False to always draw all points, even the ones considered "dead".
-        A point is "dead" when the corresponding value of `TrackedObject.live_points`
-        is set to False. If all objects are dead the object is not drawn.
-        All points of a detection are considered to be alive.
+        Set to ``False`` to draw all points, including "dead" ones. A
+        point is dead when the corresponding entry in
+        ``TrackedObject.live_points`` is ``False``. If every point is
+        dead the whole object is skipped. Detection points are always
+        treated as live.
     detections : Sequence[Detection], optional
-        **Deprecated**. use drawables.
-    label_size : Optional[int], optional
-        **Deprecated**. text_size.
+        **Deprecated.** Use ``drawables``.
+    label_size : int, optional
+        **Deprecated.** Use ``text_size``.
 
     Returns
     -------
     np.ndarray
-        The resulting frame.
+        The ``frame`` passed in (drawn on in place).
     """
     #
     # handle deprecated parameters
@@ -200,8 +202,42 @@ def draw_tracked_objects(
     draw_labels: bool = False,
     label_size: int | None = None,
 ):
-    """
-    **Deprecated** use [`draw_points`][norfair.drawing.draw_points.draw_points]
+    """Draw tracked objects onto ``frame``.
+
+    .. deprecated::
+        Use :func:`draw_points` instead. This function is kept for
+        backward compatibility and forwards its arguments to
+        :func:`draw_points`.
+
+    Parameters
+    ----------
+    frame : np.ndarray
+        The OpenCV frame to draw on. Modified in place.
+    objects : Sequence[TrackedObject]
+        The tracked objects to draw.
+    radius : int, optional
+        Radius of the circles representing each point.
+    color : ColorLike, optional
+        Color to use. See :func:`draw_points` for accepted formats.
+    id_size : float, optional
+        Size multiplier for the id text. Set to ``0`` to disable id
+        rendering.
+    id_thickness : int, optional
+        Stroke thickness of the id text.
+    draw_points : bool, optional
+        Set to ``False`` to hide the point circles and only draw text.
+    color_by_label : bool, optional
+        If ``True``, color objects by label instead of id.
+    draw_labels : bool, optional
+        If ``True``, draw the label above the points.
+    label_size : int, optional
+        Size of the label text.
+
+    Returns
+    -------
+    np.ndarray
+        The ``frame`` passed in (drawn on in place).
+
     """
     warn_once("draw_tracked_objects is deprecated, use draw_points instead")
 

--- a/norfair/drawing/drawer.py
+++ b/norfair/drawing/drawer.py
@@ -1,3 +1,5 @@
+"""Thin wrapper around OpenCV primitives used by the drawing helpers."""
+
 from collections.abc import Sequence
 from typing import Any
 
@@ -15,11 +17,11 @@ except ImportError:
 
 
 class Drawer:
-    """
-    Basic drawing functionality.
+    """Basic drawing primitives used by the higher-level helpers.
 
-    This class encapsulates opencv drawing functions allowing for
-    different backends to be implemented following the same interface.
+    This class encapsulates OpenCV drawing calls behind a stable
+    interface so alternative backends can be swapped in without
+    touching the rest of the drawing module.
     """
 
     @classmethod
@@ -31,26 +33,27 @@ class Drawer:
         thickness: int | None = None,
         color: ColorType | None = None,
     ) -> np.ndarray:
-        """
-        Draw a circle.
+        """Draw a circle onto ``frame``.
 
         Parameters
         ----------
         frame : np.ndarray
             The OpenCV frame to draw on. Modified in place.
-        position : Tuple[int, int]
-            Position of the point. This will become the center of the circle.
-        radius : Optional[int], optional
-            Radius of the circle.
-        thickness : Optional[int], optional
-            Thickness or width of the line.
-        color : Color, optional
-            A tuple of ints describing the BGR color `(0, 0, 255)`.
+        position : tuple of int
+            Center of the circle in pixel coordinates.
+        radius : int, optional
+            Radius of the circle. By default a sensible value is picked
+            based on the frame size.
+        thickness : int, optional
+            Stroke thickness. By default it is derived from ``radius``.
+        color : ColorType, optional
+            BGR color. Defaults to black.
 
         Returns
         -------
         np.ndarray
-            The resulting frame.
+            The ``frame`` passed in (drawn on in place).
+
         """
         if radius is None:
             radius = int(max(max(frame.shape) * 0.005, 1))
@@ -80,8 +83,7 @@ class Drawer:
         shadow_color: ColorType = Color.black,
         shadow_offset: int = 1,
     ) -> np.ndarray:
-        """
-        Draw text
+        """Draw text onto ``frame``.
 
         Parameters
         ----------
@@ -89,26 +91,30 @@ class Drawer:
             The OpenCV frame to draw on. Modified in place.
         text : str
             The text to be written.
-        position : Tuple[int, int]
-            Position of the bottom-left corner of the text.
-            This value is adjusted considering the thickness automatically.
-        size : Optional[float], optional
-            Scale of the font, by default chooses a sensible value is picked based on the size of the frame.
-        color : Optional[ColorType], optional
-            Color of the text, by default is black.
-        thickness : Optional[int], optional
-            Thickness of the lines, by default a sensible value is picked based on the size.
+        position : tuple of int
+            Bottom-left corner of the text in pixel coordinates. The
+            value is automatically shifted to account for ``thickness``.
+        size : float, optional
+            Font scale. By default a sensible value is picked based on
+            the frame size.
+        color : ColorType, optional
+            Text color. Defaults to black.
+        thickness : int, optional
+            Stroke thickness. By default a sensible value is derived
+            from ``size``.
         shadow : bool, optional
-            If True, a shadow of the text is added which improves legibility.
-        shadow_color : Color, optional
+            If ``True``, a shadow is drawn behind the text to improve
+            legibility.
+        shadow_color : ColorType, optional
             Color of the shadow.
         shadow_offset : int, optional
-            Offset of the shadow.
+            Pixel offset of the shadow relative to the text.
 
         Returns
         -------
         np.ndarray
-            The resulting frame.
+            The ``frame`` passed in (drawn on in place).
+
         """
         font_size = (
             size if size is not None else min(max(max(frame.shape) / 4000, 0.5), 1.5)
@@ -150,27 +156,28 @@ class Drawer:
         color: ColorType | None = None,
         thickness: int | None = None,
     ) -> np.ndarray:
-        """
-        Draw a rectangle
+        """Draw a rectangle onto ``frame``.
 
         Parameters
         ----------
         frame : np.ndarray
             The OpenCV frame to draw on. Modified in place.
-        points : Sequence[Tuple[int, int]] | np.ndarray
-            Points describing the rectangle in the format `[[x0, y0], [x1, y1]]`.
+        points : Sequence[tuple[int, int]] | np.ndarray
+            Two opposite corners of the rectangle in the format
+            ``[[x0, y0], [x1, y1]]``.
             May be passed as a nested sequence or as a ``(2, 2)`` numpy array —
             both forms are normalised to plain ``(int, int)`` tuples before
             being handed to OpenCV.
-        color : Optional[ColorType], optional
-            Color of the lines, by default Black.
-        thickness : Optional[int], optional
-            Thickness of the lines, by default 1.
+        color : ColorType, optional
+            BGR outline color. Defaults to black.
+        thickness : int, optional
+            Stroke thickness of the outline.
 
         Returns
         -------
         np.ndarray
-            The resulting frame.
+            The ``frame`` passed in (drawn on in place).
+
         """
         if color is None:
             color = Color.black
@@ -194,26 +201,26 @@ class Drawer:
         color: ColorType,
         thickness: int,
     ) -> np.ndarray:
-        """
-        Draw a cross
+        """Draw a ``+``-shaped cross onto ``frame``.
 
         Parameters
         ----------
         frame : np.ndarray
             The OpenCV frame to draw on. Modified in place.
-        center : Tuple[int, int]
-            Center of the cross.
+        center : tuple of int
+            Center of the cross in pixel coordinates.
         radius : int
-            Size or radius of the cross.
-        color : Color
-            Color of the lines.
+            Half-length of each arm of the cross.
+        color : ColorType
+            BGR color of the lines.
         thickness : int
-            Thickness of the lines.
+            Stroke thickness of the lines.
 
         Returns
         -------
         np.ndarray
-            The resulting frame.
+            The ``frame`` passed in (drawn on in place).
+
         """
         middle_x, middle_y = center
         left = center[0] - radius
@@ -245,26 +252,26 @@ class Drawer:
         color: ColorType = Color.black,
         thickness: int = 1,
     ) -> np.ndarray:
-        """
-        Draw a line.
+        """Draw a straight line onto ``frame``.
 
         Parameters
         ----------
         frame : np.ndarray
             The OpenCV frame to draw on. Modified in place.
-        start : Tuple[int, int]
-            Starting point.
-        end : Tuple[int, int]
-            End point.
+        start : tuple of int
+            Starting point in pixel coordinates.
+        end : tuple of int
+            End point in pixel coordinates.
         color : ColorType, optional
-            Line color.
+            BGR line color. Defaults to black.
         thickness : int, optional
-            Line width.
+            Stroke thickness of the line.
 
         Returns
         -------
         np.ndarray
-            The resulting frame.
+            The ``frame`` passed in (drawn on in place).
+
         """
         return cv2.line(
             frame,
@@ -283,8 +290,7 @@ class Drawer:
         beta: float | None = None,
         gamma: float = 0,
     ) -> np.ndarray:
-        """
-        Blend 2 frames as a weighted sum.
+        """Blend two frames as a weighted sum.
 
         Parameters
         ----------
@@ -293,16 +299,17 @@ class Drawer:
         frame2 : np.ndarray
             An OpenCV frame.
         alpha : float, optional
-            Weight of frame1.
-        beta : Optional[float], optional
-            Weight of frame2, by default `1 - alpha`
+            Weight of ``frame1``.
+        beta : float, optional
+            Weight of ``frame2``. Defaults to ``1 - alpha``.
         gamma : float, optional
-            Scalar to add to the sum.
+            Scalar added to the weighted sum.
 
         Returns
         -------
         np.ndarray
-            The resulting frame.
+            The blended frame.
+
         """
         if beta is None:
             beta = 1 - alpha
@@ -312,30 +319,41 @@ class Drawer:
 
 
 class Drawable:
-    """
-    Class to standardize Drawable objects like Detections and TrackedObjects
+    """Adapter that exposes ``Detection`` and ``TrackedObject`` uniformly.
+
+    The drawing helpers accept either raw ``Detection`` /
+    ``TrackedObject`` instances or pre-built ``Drawable`` objects.
+    Wrapping an object lets you draw arbitrary point sets with a
+    uniform API.
 
     Parameters
     ----------
-    obj : Union[Detection, TrackedObject], optional
-        A [Detection][norfair.tracker.Detection] or a [TrackedObject][norfair.tracker.TrackedObject]
-        that will be used to initialized the drawable.
-        If this parameter is passed, all other arguments are ignored
+    obj : Detection or TrackedObject, optional
+        A [Detection][norfair.tracker.Detection] or
+        [TrackedObject][norfair.tracker.TrackedObject] used to
+        initialize the drawable. If given, all remaining arguments are
+        ignored.
     points : np.ndarray, optional
-        Points included in the drawable, shape is `(N_points, N_dimensions)`. Ignored if `obj` is passed
+        Point array of shape ``(n_points, n_dimensions)``. Ignored
+        when ``obj`` is supplied.
     id : Any, optional
-        Id of this object. Ignored if `obj` is passed
+        Object id. Ignored when ``obj`` is supplied.
     label : Any, optional
-        Label specifying the class of the object. Ignored if `obj` is passed
+        Label describing the class of the object. Ignored when ``obj``
+        is supplied.
     scores : np.ndarray, optional
-        Confidence scores of each point, shape is `(N_points,)`. Ignored if `obj` is passed
+        Per-point confidence scores of shape ``(n_points,)``. Ignored
+        when ``obj`` is supplied.
     live_points : np.ndarray, optional
-        Bolean array indicating which points are alive, shape is `(N_points,)`. Ignored if `obj` is passed
+        Boolean mask of shape ``(n_points,)`` marking which points are
+        still alive. Ignored when ``obj`` is supplied.
 
     Raises
     ------
     ValueError
-        If obj is not an instance of the supported classes.
+        If ``obj`` is not a ``Detection``, ``TrackedObject`` or
+        ``None``.
+
     """
 
     def __init__(
@@ -347,6 +365,7 @@ class Drawable:
         scores: np.ndarray | None = None,
         live_points: np.ndarray | None = None,
     ) -> None:
+        """Initialize the drawable from ``obj`` or explicit fields."""
         if isinstance(obj, Detection):
             self.points = obj.points
             self.id = None

--- a/norfair/drawing/fixed_camera.py
+++ b/norfair/drawing/fixed_camera.py
@@ -1,3 +1,5 @@
+"""Video stabilization drawer built on camera-motion estimates."""
+
 import numpy as np
 
 from norfair.camera_motion import TranslationTransformation
@@ -5,52 +7,64 @@ from norfair.utils import warn_once
 
 
 class FixedCamera:
-    """
-    Class used to stabilize video based on the camera motion.
+    """Stabilize the video by compensating for estimated camera motion.
 
-    Starts with a larger frame, where the original frame is drawn on top of a black background.
-    As the camera moves, the smaller frame moves in the opposite direction, stabilizing the objects in it.
-
-    Useful for debugging or demoing the camera motion.
-
-    !!! Warning
-        This only works with [`TranslationTransformation`][norfair.camera_motion.TranslationTransformation],
-        using [`HomographyTransformation`][norfair.camera_motion.HomographyTransformation] will result in
-        unexpected behaviour.
+    The drawer renders on a larger canvas and shifts the original
+    frame in the opposite direction of the camera motion, so stationary
+    objects in the world stay pinned in the output. Useful for
+    debugging or showcasing camera-motion estimation.
 
     !!! Warning
-        If using other drawers, always apply this one last. Using other drawers on the scaled up frame will not work as expected.
+        Only supports
+        [`TranslationTransformation`][norfair.camera_motion.TranslationTransformation].
+        Passing a
+        [`HomographyTransformation`][norfair.camera_motion.HomographyTransformation]
+        yields undefined behavior.
+
+    !!! Warning
+        If combined with other drawers, always apply ``FixedCamera``
+        last. Drawing on the scaled-up frame produced by this class
+        will not give the expected result.
 
     !!! Note
-        Sometimes the camera moves so far from the original point that the result won't fit in the scaled-up frame.
-        In this case, a warning will be logged and the frames will be cropped to avoid errors.
+        Sometimes the camera moves so far from the starting point that
+        the shifted frame no longer fits inside the scaled-up canvas.
+        In that case, a warning is logged and the frame is cropped.
 
     Parameters
     ----------
     scale : float, optional
-        The resulting video will have a resolution of `scale * (H, W)` where HxW is the resolution of the original video.
-        Use a bigger scale if the camera is moving too much.
+        The output resolution is ``scale * (H, W)`` where ``H, W`` is
+        the resolution of the input frame. Increase this when the
+        camera moves a lot.
     attenuation : float, optional
-        Controls how fast the older frames fade to black.
+        Controls how quickly older content fades toward black.
 
     Examples
     --------
-    >>> # setup
-    >>> tracker = Tracker("frobenious", 100)
-    >>> motion_estimator = MotionEstimator()
-    >>> video = Video(input_path="video.mp4")
-    >>> fixed_camera = FixedCamera()
-    >>> # process video
-    >>> for frame in video:
-    >>>     coord_transformations = motion_estimator.update(frame)
-    >>>     detections = get_detections(frame)
-    >>>     tracked_objects = tracker.update(detections, coord_transformations)
-    >>>     draw_tracked_objects(frame, tracked_objects)  # fixed_camera should always be the last drawer
-    >>>     bigger_frame = fixed_camera.adjust_frame(frame, coord_transformations)
-    >>>     video.write(bigger_frame)
+    Stabilize a video using ``FixedCamera`` alongside a tracker::
+
+        >>> tracker = Tracker("frobenius", 100)
+        >>> motion_estimator = MotionEstimator()
+        >>> fixed_camera = FixedCamera()
+        >>> with Video(input_path="video.mp4") as video:
+        ...     for frame in video:
+        ...         coord_transformations = motion_estimator.update(frame)
+        ...         detections = get_detections(frame)
+        ...         tracked_objects = tracker.update(
+        ...             detections, coord_transformations=coord_transformations
+        ...         )
+        ...         # apply fixed_camera last
+        ...         draw_points(frame, tracked_objects)
+        ...         bigger_frame = fixed_camera.adjust_frame(
+        ...             frame, coord_transformations
+        ...         )
+        ...         video.write(bigger_frame)
+
     """
 
     def __init__(self, scale: float = 2, attenuation: float = 0.05):
+        """Initialize the background canvas parameters."""
         self.scale = scale
         self._background: np.ndarray | None = None
         self._attenuation_factor = 1 - attenuation
@@ -58,20 +72,24 @@ class FixedCamera:
     def adjust_frame(
         self, frame: np.ndarray, coord_transformation: TranslationTransformation
     ) -> np.ndarray:
-        """
-        Render scaled up frame.
+        """Render the next frame onto the stabilized background canvas.
 
         Parameters
         ----------
         frame : np.ndarray
-            The OpenCV frame.
+            The OpenCV frame for this time step.
         coord_transformation : TranslationTransformation
-            The coordinate transformation as returned by the [`MotionEstimator`][norfair.camera_motion.MotionEstimator]
+            The coordinate transformation as returned by the
+            [`MotionEstimator`][norfair.camera_motion.MotionEstimator]
+            for this frame.
 
         Returns
         -------
         np.ndarray
-            The new bigger frame with the original frame drawn on it.
+            The scaled-up background canvas with ``frame`` drawn onto
+            it at the position that compensates for the estimated
+            camera motion.
+
         """
 
         # initialize background if necessary

--- a/norfair/drawing/path.py
+++ b/norfair/drawing/path.py
@@ -40,7 +40,7 @@ class Paths:
         >>> from norfair import Paths, Tracker, Video
         >>> tracker = Tracker(...)
         >>> path_drawer = Paths()
-        >>> with Video("video.mp4") as video:
+        >>> with Video(input_path="video.mp4") as video:
         ...     for frame in video:
         ...         detections = get_detections(frame)
         ...         tracked_objects = tracker.update(detections)
@@ -178,7 +178,7 @@ class AbsolutePaths:
         >>> tracker = Tracker(...)
         >>> motion_estimator = MotionEstimator()
         >>> path_drawer = AbsolutePaths()
-        >>> with Video("video.mp4") as video:
+        >>> with Video(input_path="video.mp4") as video:
         ...     for frame in video:
         ...         coord_transform = motion_estimator.update(frame)
         ...         detections = get_detections(frame)

--- a/norfair/drawing/path.py
+++ b/norfair/drawing/path.py
@@ -1,3 +1,5 @@
+"""Drawers that trace the trajectories of tracked points across frames."""
+
 from collections import defaultdict
 from collections.abc import Callable, Sequence
 
@@ -10,37 +12,41 @@ from norfair.utils import warn_once
 
 
 class Paths:
-    """
-    Class that draws the paths taken by a set of points of interest defined from the coordinates of each tracker estimation.
+    """Draw the trajectories of points of interest on each tracked object.
 
     Parameters
     ----------
-    get_points_to_draw : Optional[Callable[[np.ndarray], np.ndarray]], optional
-        Function that takes a list of points (the `.estimate` attribute of a [`TrackedObject`][norfair.tracker.TrackedObject])
-        and returns a list of points for which we want to draw their paths.
-
-        By default it is the mean point of all the points in the tracker.
-    thickness : Optional[int], optional
-        Thickness of the circles representing the paths of interest.
-    color : Optional[Tuple[int, int, int]], optional
-        [Color][norfair.drawing.Color] of the circles representing the paths of interest.
-    radius : Optional[int], optional
-        Radius of the circles representing the paths of interest.
+    get_points_to_draw : callable, optional
+        Callable taking the ``.estimate`` of a
+        [`TrackedObject`][norfair.tracker.TrackedObject] and returning
+        a sequence of points whose paths should be drawn. By default
+        the mean of all points in the tracker is used.
+    thickness : int, optional
+        Thickness of the circles representing the path.
+    color : tuple of int, optional
+        BGR [Color][norfair.drawing.Color] of the path circles. By
+        default the color is selected from the active
+        [`Palette`][norfair.drawing.Palette] based on the object's id.
+    radius : int, optional
+        Radius of the circles representing the path.
     attenuation : float, optional
-        A float number in [0, 1] that dictates the speed at which the path is erased.
-        if it is `0` then the path is never erased.
+        Value in ``[0, 1]`` controlling how fast existing path pixels
+        fade between frames. Use ``0`` to keep the path forever.
 
     Examples
     --------
-    >>> from norfair import Tracker, Video, Path
-    >>> video = Video("video.mp4")
-    >>> tracker = Tracker(...)
-    >>> path_drawer = Path()
-    >>> for frame in video:
-    >>>    detections = get_detections(frame)  # runs detector and returns Detections
-    >>>    tracked_objects = tracker.update(detections)
-    >>>    frame = path_drawer.draw(frame, tracked_objects)
-    >>>    video.write(frame)
+    Overlay trajectories on top of tracked objects::
+
+        >>> from norfair import Paths, Tracker, Video
+        >>> tracker = Tracker(...)
+        >>> path_drawer = Paths()
+        >>> with Video("video.mp4") as video:
+        ...     for frame in video:
+        ...         detections = get_detections(frame)
+        ...         tracked_objects = tracker.update(detections)
+        ...         frame = path_drawer.draw(frame, tracked_objects)
+        ...         video.write(frame)
+
     """
 
     def __init__(
@@ -51,6 +57,7 @@ class Paths:
         radius: int | None = None,
         attenuation: float = 0.01,
     ):
+        """Configure the path drawer with its rendering knobs."""
         if get_points_to_draw is None:
 
             def default_get_points(points):
@@ -71,23 +78,26 @@ class Paths:
     def draw(
         self, frame: np.ndarray, tracked_objects: Sequence[TrackedObject]
     ) -> np.ndarray:
-        """
-        Draw the paths of the points interest on a frame.
+        """Update and render the accumulated path mask onto ``frame``.
 
         !!! warning
-            This method does **not** draw frames in place as other drawers do, the resulting frame is returned.
+            Unlike most other drawers, this method does **not** mutate
+            ``frame`` in place — the blended result is returned.
 
         Parameters
         ----------
         frame : np.ndarray
             The OpenCV frame to draw on.
         tracked_objects : Sequence[TrackedObject]
-            List of [`TrackedObject`][norfair.tracker.TrackedObject] to get the points of interest in order to update the paths.
+            The [`TrackedObject`][norfair.tracker.TrackedObject] list
+            whose points-of-interest are appended to the running path
+            mask for this frame.
 
         Returns
         -------
-        np.array
-            The resulting frame.
+        np.ndarray
+            A new frame with the current path mask blended on top.
+
         """
         if self.mask is None:
             frame_scale = frame.shape[0] / 100
@@ -129,42 +139,55 @@ class Paths:
 
 
 class AbsolutePaths:
-    """
-    Class that draws the absolute paths taken by a set of points.
+    """Draw tracked-object trajectories in absolute (world) coordinates.
 
-    Works just like [`Paths`][norfair.drawing.Paths] but supports camera motion.
+    Behaves like [`Paths`][norfair.drawing.Paths], but takes camera
+    motion into account so trajectories stay pinned to the world
+    frame.
 
     !!! warning
-        This drawer is not optimized so it can be stremely slow. Performance degrades linearly with
-        `max_history * number_of_tracked_objects`.
+        This drawer is not optimized and can be extremely slow:
+        rendering cost grows linearly with
+        ``max_history * number_of_tracked_objects``.
 
     Parameters
     ----------
-    get_points_to_draw : Optional[Callable[[np.ndarray], np.ndarray]], optional
-        Function that takes a list of points (the `.estimate` attribute of a [`TrackedObject`][norfair.tracker.TrackedObject])
-        and returns a list of points for which we want to draw their paths.
-
-        By default it is the mean point of all the points in the tracker.
-    thickness : Optional[int], optional
-        Thickness of the circles representing the paths of interest.
-    color : Optional[Tuple[int, int, int]], optional
-        [Color][norfair.drawing.Color] of the circles representing the paths of interest.
-    radius : Optional[int], optional
-        Radius of the circles representing the paths of interest.
+    get_points_to_draw : callable, optional
+        Callable taking the ``.estimate`` of a
+        [`TrackedObject`][norfair.tracker.TrackedObject] and returning
+        a sequence of points whose paths should be drawn. By default
+        the mean of all points in the tracker is used.
+    thickness : int, optional
+        Thickness of the circles / connecting lines.
+    color : tuple of int, optional
+        BGR [Color][norfair.drawing.Color] used for every object. By
+        default the color is selected from the active palette based on
+        the object's id.
+    radius : int, optional
+        Radius of the circles representing the latest point.
     max_history : int, optional
-        Number of past points to include in the path. High values make the drawing slower
+        Number of past samples to include in the path. Higher values
+        make the drawing slower.
 
     Examples
     --------
-    >>> from norfair import Tracker, Video, Path
-    >>> video = Video("video.mp4")
-    >>> tracker = Tracker(...)
-    >>> path_drawer = Path()
-    >>> for frame in video:
-    >>>    detections = get_detections(frame)  # runs detector and returns Detections
-    >>>    tracked_objects = tracker.update(detections)
-    >>>    frame = path_drawer.draw(frame, tracked_objects)
-    >>>    video.write(frame)
+    Overlay trajectories on top of tracked objects while accounting
+    for camera motion::
+
+        >>> from norfair import AbsolutePaths, MotionEstimator, Tracker, Video
+        >>> tracker = Tracker(...)
+        >>> motion_estimator = MotionEstimator()
+        >>> path_drawer = AbsolutePaths()
+        >>> with Video("video.mp4") as video:
+        ...     for frame in video:
+        ...         coord_transform = motion_estimator.update(frame)
+        ...         detections = get_detections(frame)
+        ...         tracked_objects = tracker.update(
+        ...             detections, coord_transformations=coord_transform
+        ...         )
+        ...         frame = path_drawer.draw(frame, tracked_objects, coord_transform)
+        ...         video.write(frame)
+
     """
 
     def __init__(
@@ -175,6 +198,7 @@ class AbsolutePaths:
         radius: int | None = None,
         max_history=20,
     ):
+        """Configure the absolute-coordinates path drawer."""
         if get_points_to_draw is None:
 
             def default_get_points(points):
@@ -194,6 +218,26 @@ class AbsolutePaths:
         self.alphas = np.linspace(0.99, 0.01, max_history)
 
     def draw(self, frame, tracked_objects, coord_transform=None):
+        """Render accumulated absolute paths onto ``frame``.
+
+        Parameters
+        ----------
+        frame : np.ndarray
+            The OpenCV frame to draw on. Modified in place.
+        tracked_objects : Sequence[TrackedObject]
+            Tracked objects whose absolute trajectories are updated
+            and rendered for this frame.
+        coord_transform : CoordinatesTransformation, optional
+            Transformation between absolute and relative coordinates
+            for the current frame. When ``None``, points are assumed
+            to already be in the frame's pixel coordinates.
+
+        Returns
+        -------
+        np.ndarray
+            The ``frame`` passed in, with the paths blended on top.
+
+        """
         frame_scale = frame.shape[0] / 100
 
         if self.radius is None:

--- a/norfair/drawing/utils.py
+++ b/norfair/drawing/utils.py
@@ -1,3 +1,5 @@
+"""Small private helpers shared by the drawing functions."""
+
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -7,6 +9,7 @@ if TYPE_CHECKING:
 
 
 def _centroid(tracked_points: np.ndarray) -> tuple[int, int]:
+    """Return the integer centroid of ``tracked_points``."""
     num_points = tracked_points.shape[0]
     sum_x = np.sum(tracked_points[:, 0])
     sum_y = np.sum(tracked_points[:, 1])
@@ -14,6 +17,7 @@ def _centroid(tracked_points: np.ndarray) -> tuple[int, int]:
 
 
 def _build_text(drawable: "Drawable", draw_labels, draw_ids, draw_scores):
+    """Assemble the ``label-id-score`` string displayed next to an object."""
     text = ""
     if draw_labels and drawable.label is not None:
         text = str(drawable.label)

--- a/norfair/filter.py
+++ b/norfair/filter.py
@@ -1,3 +1,5 @@
+"""Predictive filter factories used by ``Tracker`` to estimate object motion."""
+
 from abc import ABC, abstractmethod
 from typing import Protocol
 
@@ -11,7 +13,9 @@ class Filter(Protocol):
 
     x: np.ndarray
 
-    def predict(self) -> None: ...
+    def predict(self) -> None:
+        """Advance the internal state one step forward in time."""
+        ...
 
     def update(
         self,
@@ -19,42 +23,57 @@ class Filter(Protocol):
         /,
         R: np.ndarray | None = None,
         H: np.ndarray | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Incorporate a new measurement ``z`` into the state."""
+        ...
 
 
 class FilterFactory(ABC):
-    """Abstract class representing a generic Filter factory
+    """Abstract base class for predictive-filter factories.
 
-    Subclasses must implement the method `create_filter`
+    Subclasses must implement :meth:`create_filter`, which returns a new
+    filter instance for each tracked object.
     """
 
     @abstractmethod
     def create_filter(self, initial_detection: np.ndarray) -> Filter:
-        pass
+        """Return a new filter seeded with ``initial_detection``."""
+        ...
 
 
 class FilterPyKalmanFilterFactory(FilterFactory):
-    """
-    This class can be used either to change some parameters of the [KalmanFilter](https://filterpy.readthedocs.io/en/latest/kalman/KalmanFilter.html)
-    that the tracker uses, or to fully customize the predictive filter implementation to use (as long as the methods and properties are compatible).
+    """Factory for filterpy-backed Kalman filters.
 
-    The former case only requires changing the default parameters upon tracker creation: `tracker = Tracker(..., filter_factory=FilterPyKalmanFilterFactory(R=100))`,
-    while the latter requires creating your own class extending `FilterPyKalmanFilterFactory`, and rewriting its `create_filter` method to return your own customized filter.
+    Use this factory to either tweak the parameters of the
+    [KalmanFilter](https://filterpy.readthedocs.io/en/latest/kalman/KalmanFilter.html)
+    that the tracker uses, or to fully customize the predictive filter
+    implementation (as long as the methods and properties are compatible).
+
+    In the first case, only the default parameters need to be tweaked at
+    tracker creation time::
+
+        tracker = Tracker(..., filter_factory=FilterPyKalmanFilterFactory(R=100))
+
+    In the second case, create your own subclass of
+    ``FilterPyKalmanFilterFactory`` and override :meth:`create_filter` to
+    return your customized filter.
 
     Parameters
     ----------
     R : float, optional
-        Multiplier for the sensor measurement noise matrix, by default 4.0.
-        Larger values make the filter trust measurements less and rely more
-        on its own predictions — useful when detections are noisy.
+        Multiplier for the sensor measurement noise matrix. Defaults to
+        ``4.0``. Larger values make the filter trust measurements less
+        and rely more on its own predictions — useful when detections
+        are noisy.
     Q : float, optional
-        Multiplier for the process uncertainty, by default 0.1.
-        Larger values let the filter react faster to real motion changes but
-        increase jitter; smaller values produce smoother but laggier tracks.
+        Multiplier for the process uncertainty. Defaults to ``0.1``.
+        Larger values let the filter react faster to real motion changes
+        but increase jitter; smaller values produce smoother but laggier
+        tracks.
     P : float, optional
-        Multiplier for the initial covariance matrix estimation, only in the
-        entries that correspond to position (not speed) variables, by default
-        10.0.
+        Multiplier for the initial covariance matrix estimation, only in
+        the entries that correspond to position (not speed) variables.
+        Defaults to ``10.0``.
 
     Notes
     -----
@@ -66,7 +85,8 @@ class FilterPyKalmanFilterFactory(FilterFactory):
 
     See Also
     --------
-    [`filterpy.KalmanFilter`](https://filterpy.readthedocs.io/en/latest/kalman/KalmanFilter.html).
+    [`filterpy.KalmanFilter`](https://filterpy.readthedocs.io/en/latest/kalman/KalmanFilter.html)
+
     """
 
     def __init__(self, R: float = 4.0, Q: float = 0.1, P: float = 10.0):
@@ -75,20 +95,25 @@ class FilterPyKalmanFilterFactory(FilterFactory):
         self.P = P
 
     def create_filter(self, initial_detection: np.ndarray) -> KalmanFilter:
-        """
-        This method returns a new predictive filter instance with the current setup, to be used by each new [`TrackedObject`][norfair.tracker.TrackedObject] that is created.
-        This predictive filter will be used to estimate speed and future positions of the object, to better match the detections during its trajectory.
+        """Return a new Kalman filter seeded with ``initial_detection``.
+
+        The returned filter is used by each new
+        [`TrackedObject`][norfair.tracker.TrackedObject] to estimate speed
+        and future positions so detections can be matched along the
+        trajectory.
 
         Parameters
         ----------
         initial_detection : np.ndarray
-            numpy array of shape `(number of points per object, 2)`, corresponding to the [`Detection.points`][norfair.tracker.Detection] of the tracked object being born,
-            which shall be used as initial position estimation for it.
+            Array of shape ``(n_points, n_dimensions)`` corresponding to
+            [`Detection.points`][norfair.tracker.Detection] of the tracked
+            object being born, used as the initial position estimate.
 
         Returns
         -------
         KalmanFilter
-            The kalman filter
+            A freshly initialized Kalman filter.
+
         """
         num_points = initial_detection.shape[0]
         dim_points = initial_detection.shape[1]
@@ -127,14 +152,34 @@ class FilterPyKalmanFilterFactory(FilterFactory):
 
 
 class NoFilter:
+    """Null filter that keeps the last observation as its state.
+
+    Used by :class:`NoFilterFactory` to disable predictive filtering.
+    """
+
     def __init__(self, dim_x, dim_z):
+        """Initialize the null filter with a zero state vector of length ``dim_x``."""
         self.dim_z = dim_z
         self.x = np.zeros((dim_x, 1))
 
     def predict(self):
+        """No-op predict step — the state does not evolve between updates."""
         return
 
     def update(self, detection_points_flatten, R=None, H=None):
+        """Overwrite the position portion of the state with the new detection.
+
+        Parameters
+        ----------
+        detection_points_flatten : np.ndarray
+            Column vector of flattened detection points.
+        R : np.ndarray, optional
+            Ignored. Kept for API compatibility with filterpy filters.
+        H : np.ndarray, optional
+            Measurement function. Only its diagonal is used, to mask out
+            points that were not observed in the current frame.
+
+        """
         if H is not None:
             diagonal = np.diagonal(H).reshape((self.dim_z, 1))
             one_minus_diagonal = 1 - diagonal
@@ -147,18 +192,20 @@ class NoFilter:
 
 
 class NoFilterFactory(FilterFactory):
-    """
-    This class allows the user to try Norfair without any predictive filter or velocity estimation.
+    """Factory producing a null filter with no velocity estimation.
 
-    This track only by comparing the position of the previous detections to the ones in the current frame.
+    Lets the user try Norfair without any predictive filtering: tracking is
+    performed only by comparing the position of previous detections to
+    those in the current frame.
 
-    The throughput of this class in FPS is similar to the one achieved by the
-    [`OptimizedKalmanFilterFactory`](#optimizedkalmanfilterfactory) class, so this class exists only for
-    comparative purposes and it is not advised to use it for tracking on a real application.
-
+    The throughput of this class in FPS is similar to that of
+    [`OptimizedKalmanFilterFactory`][norfair.filter.OptimizedKalmanFilterFactory],
+    so this class exists only for comparative purposes and is not advised
+    for real-world tracking.
     """
 
     def create_filter(self, initial_detection: np.ndarray):
+        """Return a :class:`NoFilter` seeded with ``initial_detection``."""
         num_points = initial_detection.shape[0]
         dim_points = initial_detection.shape[1]
         dim_z = dim_points * num_points  # flattened positions
@@ -173,6 +220,13 @@ class NoFilterFactory(FilterFactory):
 
 
 class OptimizedKalmanFilter:
+    """A Kalman filter specialized and vectorized for Norfair tracking.
+
+    This implementation exploits the structural properties of Norfair's
+    tracking problem (diagonal covariance, independent axes) to be faster
+    than the generic ``filterpy`` implementation.
+    """
+
     def __init__(
         self,
         dim_x: int,
@@ -183,6 +237,7 @@ class OptimizedKalmanFilter:
         q: float = 0.1,
         r: float = 4.0,
     ):
+        """Initialize the filter state and per-axis variance buffers."""
         self.dim_z = dim_z
         self.x = np.zeros((dim_x, 1))
 
@@ -196,9 +251,24 @@ class OptimizedKalmanFilter:
         self.default_r = r * np.ones((dim_z, 1))
 
     def predict(self):
+        """Advance positions by the current velocity estimate."""
         self.x[: self.dim_z] += self.x[self.dim_z :]
 
     def update(self, detection_points_flatten, R=None, H=None):
+        """Fold a new measurement into the filter state.
+
+        Parameters
+        ----------
+        detection_points_flatten : np.ndarray
+            Column vector of flattened detection points.
+        R : np.ndarray, optional
+            Measurement noise matrix. Only the diagonal is used; when
+            ``None``, falls back to the factory default.
+        H : np.ndarray, optional
+            Measurement function. Only the diagonal is used, to select
+            which points were actually observed.
+
+        """
         if H is not None:
             diagonal = np.diagonal(H).reshape((self.dim_z, 1))
             one_minus_diagonal = 1 - diagonal
@@ -254,10 +324,11 @@ class OptimizedKalmanFilter:
 
 
 class OptimizedKalmanFilterFactory(FilterFactory):
-    """
-    Creates faster Filters than [`FilterPyKalmanFilterFactory`][norfair.filter.FilterPyKalmanFilterFactory].
+    """Factory for the vectorized :class:`OptimizedKalmanFilter`.
 
-    It allows the user to create Kalman Filter optimized for tracking and set its parameters.
+    Produces filters that are faster than those returned by
+    [`FilterPyKalmanFilterFactory`][norfair.filter.FilterPyKalmanFilterFactory]
+    and exposes the most relevant tuning knobs.
 
     Parameters
     ----------
@@ -270,11 +341,15 @@ class OptimizedKalmanFilterFactory(FilterFactory):
         react faster to real motion changes but increase jitter; smaller
         values produce smoother but laggier tracks.
     pos_variance : float, optional
-        Multiplier for the initial covariance matrix estimation, only in the entries that correspond to position (not speed) variables.
+        Multiplier for the initial covariance matrix estimation in the
+        entries that correspond to position (not speed) variables.
     pos_vel_covariance : float, optional
-        Multiplier for the initial covariance matrix estimation, only in the entries that correspond to the covariance between position and speed.
+        Multiplier for the initial covariance matrix estimation in the
+        entries that correspond to the covariance between position and
+        velocity.
     vel_variance : float, optional
-        Multiplier for the initial covariance matrix estimation, only in the entries that correspond to velocity (not position) variables.
+        Multiplier for the initial covariance matrix estimation in the
+        entries that correspond to velocity (not position) variables.
 
     Notes
     -----
@@ -292,6 +367,7 @@ class OptimizedKalmanFilterFactory(FilterFactory):
         pos_vel_covariance: float = 0,
         vel_variance: float = 1,
     ):
+        """Store the factory-wide tuning parameters."""
         self.R = R
         self.Q = Q
 
@@ -301,6 +377,7 @@ class OptimizedKalmanFilterFactory(FilterFactory):
         self.vel_variance = vel_variance
 
     def create_filter(self, initial_detection: np.ndarray):
+        """Return an :class:`OptimizedKalmanFilter` seeded with ``initial_detection``."""
         num_points = initial_detection.shape[0]
         dim_points = initial_detection.shape[1]
         dim_z = dim_points * num_points  # flattened positions

--- a/norfair/metrics.py
+++ b/norfair/metrics.py
@@ -1,3 +1,5 @@
+"""MOTChallenge-style I/O helpers and accumulators for the evaluation suite."""
+
 import os
 from collections import OrderedDict
 
@@ -19,13 +21,48 @@ except ImportError:
 
 
 class InformationFile:
+    """Tiny reader for MOTChallenge ``seqinfo.ini`` style metadata files.
+
+    Loads the file once at construction time and exposes a simple
+    :meth:`search` method to look up ``key=value`` pairs.
+
+    Parameters
+    ----------
+    file_path : str
+        Path to the ``seqinfo.ini`` (or similarly formatted) file.
+
+    """
+
     def __init__(self, file_path: str):
+        """Read ``file_path`` into memory and split it into lines."""
         self.path = file_path
         with open(file_path) as myfile:
             file = myfile.read()
         self.lines = file.splitlines()
 
     def search(self, variable_name: str) -> int | str:
+        """Return the value of ``variable_name`` in the loaded file.
+
+        Integer-looking values are returned as ``int``; everything
+        else is returned as ``str``.
+
+        Parameters
+        ----------
+        variable_name : str
+            Key to look up, matched as a line prefix followed by an
+            ``=``.
+
+        Returns
+        -------
+        int or str
+            The parsed value.
+
+        Raises
+        ------
+        ValueError
+            If ``variable_name`` is not found.
+
+        """
         result: str
         for line in self.lines:
             if line[: len(variable_name)] == variable_name:
@@ -40,10 +77,24 @@ class InformationFile:
 
 
 class PredictionsTextFile:
-    """Generates a text file with your predicted tracked objects, in the MOTChallenge format.
-    It needs the 'input_path', which is the path to the sequence being processed,
-    the 'save_path', and optionally the 'information_file' (in case you don't give an
-    'information_file', is assumed there is one in the input_path folder).
+    """Write tracked objects to a MOTChallenge-format predictions file.
+
+    Each call to :meth:`update` appends one row per tracked object
+    for the current frame; the file is closed automatically once the
+    number of frames hits the sequence length, or explicitly via
+    :meth:`close`.
+
+    Parameters
+    ----------
+    input_path : str
+        Path to the sequence being processed.
+    save_path : str, optional
+        Directory under which a ``predictions/`` folder is created
+        for the output file.
+    information_file : InformationFile, optional
+        Pre-parsed ``seqinfo.ini`` wrapper. When omitted, one is
+        loaded from ``input_path/seqinfo.ini``.
+
     """
 
     def __init__(
@@ -52,6 +103,7 @@ class PredictionsTextFile:
         save_path: str = ".",
         information_file: InformationFile | None = None,
     ):
+        """Create the output file and record the sequence length."""
         file_name = os.path.split(input_path)[1]
 
         if information_file is None:
@@ -74,9 +126,20 @@ class PredictionsTextFile:
         self.frame_number = 1
 
     def update(self, predictions, frame_number=None):
-        """
-        Write tracked object information in the output file (for this frame), in the format
-        frame_number, id, bb_left, bb_top, bb_width, bb_height, -1, -1, -1, -1
+        """Write ``predictions`` for the current frame to the output file.
+
+        The output line format is::
+
+            frame_number, id, bb_left, bb_top, bb_width, bb_height, -1, -1, -1, -1
+
+        Parameters
+        ----------
+        predictions : iterable of TrackedObject
+            Objects tracked for the current frame.
+        frame_number : int, optional
+            Override for the frame index. When ``None``, the internal
+            counter is used.
+
         """
         if frame_number is None:
             frame_number = self.frame_number
@@ -115,15 +178,30 @@ class PredictionsTextFile:
             self.text_file.close()
 
     def __del__(self):
+        """Ensure the underlying file is closed on garbage collection."""
         self.close()
 
 
 class DetectionFileParser:
-    """Get Norfair detections from MOTChallenge text files containing detections"""
+    """Parse MOTChallenge ``det/det.txt`` files into Norfair detections.
+
+    Pre-sorts detections by frame so that iterating the parser yields
+    a list of :class:`Detection` for each frame in order.
+
+    Parameters
+    ----------
+    input_path : str
+        Path to the MOTChallenge sequence directory.
+    information_file : InformationFile, optional
+        Pre-parsed ``seqinfo.ini`` wrapper. When omitted, one is
+        loaded from ``input_path/seqinfo.ini``.
+
+    """
 
     def __init__(
         self, input_path: str, information_file: InformationFile | None = None
     ):
+        """Load and pre-sort the detections matrix."""
         self.frame_number = 1
 
         # Get detecions matrix data with rows corresponding to:
@@ -156,8 +234,7 @@ class DetectionFileParser:
             self.sorted_by_frame.append(self.get_dets_from_frame(frame_number))
 
     def get_dets_from_frame(self, frame_number):
-        """this function returns a list of norfair Detections class, corresponding to frame=frame_number"""
-
+        """Return the list of Norfair ``Detection`` for ``frame_number``."""
         indexes = np.argwhere(self.matrix_detections[:, 0] == frame_number)
         detections = []
         if len(indexes) > 0:
@@ -172,10 +249,12 @@ class DetectionFileParser:
         return detections
 
     def __iter__(self):
+        """Reset the frame counter and return ``self`` as an iterator."""
         self.frame_number = 1
         return self
 
     def __next__(self):
+        """Return the detection list for the next frame in the sequence."""
         if self.frame_number <= self.length:
             self.frame_number += 1
             # Frame_number is always 1 unit bigger than the corresponding index in self.sorted_by_frame, and
@@ -186,11 +265,30 @@ class DetectionFileParser:
 
 
 class Accumulators:
+    """Collect tracker outputs across sequences for MOT metrics evaluation.
+
+    Each sequence is opened with :meth:`create_accumulator`, fed
+    frame-by-frame via :meth:`update`, and finally evaluated with
+    :meth:`compute_metrics` to produce a dataframe of metrics.
+    """
+
     def __init__(self):
+        """Initialize the per-sequence prediction buffers."""
         self.matrixes_predictions = []
         self.paths = []
 
     def create_accumulator(self, input_path, information_file=None):
+        """Start collecting predictions for the sequence at ``input_path``.
+
+        Parameters
+        ----------
+        input_path : str
+            Path to the MOTChallenge sequence directory.
+        information_file : InformationFile, optional
+            Pre-parsed ``seqinfo.ini`` wrapper. When omitted, one is
+            loaded from ``input_path/seqinfo.ini``.
+
+        """
         # Check that motmetrics is installed here, so we don't have to process
         # the whole dataset before failing out if we don't.
         mm.metrics  # noqa: B018 — intentional attribute access to fail early if motmetrics not installed
@@ -218,6 +316,15 @@ class Accumulators:
         )
 
     def update(self, predictions=None):
+        """Append ``predictions`` for the current frame and advance the bar.
+
+        Parameters
+        ----------
+        predictions : iterable of TrackedObject, optional
+            Objects tracked for the current frame. When ``None``, the
+            frame is recorded as empty but still advances the counter.
+
+        """
         # Get the tracked boxes from this frame in an array
         if predictions is not None:
             for obj in predictions:
@@ -247,6 +354,24 @@ class Accumulators:
         metrics=None,
         generate_overall=True,
     ):
+        """Compute MOTChallenge metrics over all collected sequences.
+
+        Parameters
+        ----------
+        metrics : list of str, optional
+            Subset of ``motmetrics`` metrics to compute. Defaults to
+            the full MOTChallenge list.
+        generate_overall : bool, optional
+            If ``True``, include an ``OVERALL`` row aggregating every
+            sequence.
+
+        Returns
+        -------
+        pandas.DataFrame
+            Dataframe of per-sequence metrics (and overall if
+            requested). Also stored on ``self.summary_dataframe``.
+
+        """
         if metrics is None:
             metrics = list(mm.metrics.motchallenge_metrics)
 
@@ -260,6 +385,7 @@ class Accumulators:
         return self.summary_dataframe
 
     def save_metrics(self, save_path=".", file_name="metrics.txt"):
+        """Write the rendered ``summary_text`` to ``save_path/file_name``."""
         if not os.path.exists(save_path):
             os.makedirs(save_path)
 
@@ -269,31 +395,33 @@ class Accumulators:
         metrics_file.close()
 
     def print_metrics(self):
+        """Print the rendered ``summary_text`` to stdout."""
         print(self.summary_text)
 
 
 def load_motchallenge(matrix_data, min_confidence=-1):
-    """Load MOT challenge data.
+    """Load MOTChallenge-formatted predictions from a numpy array.
 
-    This is a modification of the function load_motchallenge from the py-motmetrics library, defined in io.py
-    In this version, the pandas dataframe is generated from a numpy array (matrix_data) instead of a text file.
+    Adapted from ``motmetrics.io.loadtxt`` but reading from an
+    in-memory array instead of a text file.
 
-    Params
-    ------
-    matrix_data : array  of float that has [frame, id, X, Y, width, height, conf, cassId, visibility] in each row, for each prediction on a particular video
-
-    min_confidence : float
-        Rows with confidence less than this threshold are removed.
-        Defaults to -1. You should set this to 1 when loading
-        ground truth MOTChallenge data, so that invalid rectangles in
-        the ground truth are not considered during matching.
+    Parameters
+    ----------
+    matrix_data : np.ndarray
+        Float array whose rows contain
+        ``[frame, id, X, Y, width, height, conf, classId, visibility]``.
+    min_confidence : float, optional
+        Rows with ``Confidence < min_confidence`` are dropped. Set
+        this to ``1`` when loading MOTChallenge ground truth so
+        invalid rectangles are ignored during matching.
 
     Returns
-    ------
-    df : pandas.DataFrame
-        The returned dataframe has the following columns
-            'X', 'Y', 'Width', 'Height', 'Confidence', 'ClassId', 'Visibility'
-        The dataframe is indexed by ('FrameId', 'Id')
+    -------
+    pandas.DataFrame
+        Dataframe with columns ``['X', 'Y', 'Width', 'Height',
+        'Confidence', 'ClassId', 'Visibility']``, indexed by
+        ``('FrameId', 'Id')``.
+
     """
 
     df = pd.DataFrame(
@@ -323,7 +451,22 @@ def load_motchallenge(matrix_data, min_confidence=-1):
 
 
 def compare_dataframes(gts, ts):
-    """Builds accumulator for each sequence."""
+    """Build a ``motmetrics`` accumulator per sequence.
+
+    Parameters
+    ----------
+    gts : dict of str to pandas.DataFrame
+        Mapping of sequence name to ground-truth dataframe.
+    ts : dict of str to pandas.DataFrame
+        Mapping of sequence name to tracker-output dataframe.
+
+    Returns
+    -------
+    tuple of (list, list)
+        ``(accs, names)`` — the accumulators and the corresponding
+        sequence names, in matching order.
+
+    """
     accs = []
     names = []
     for k, tsacc in ts.items():
@@ -338,6 +481,30 @@ def compare_dataframes(gts, ts):
 
 
 def eval_motChallenge(matrixes_predictions, paths, metrics=None, generate_overall=True):
+    """Evaluate tracker predictions against MOTChallenge ground truth.
+
+    Parameters
+    ----------
+    matrixes_predictions : list of np.ndarray
+        Per-sequence prediction arrays in the format accepted by
+        :func:`load_motchallenge`.
+    paths : sequence of str
+        Paths to the corresponding MOTChallenge sequence directories;
+        ground truth is read from ``<path>/gt/gt.txt``.
+    metrics : list of str, optional
+        Metric names to compute. Defaults to the full MOTChallenge
+        list.
+    generate_overall : bool, optional
+        If ``True``, include an ``OVERALL`` row aggregating every
+        sequence.
+
+    Returns
+    -------
+    tuple of (str, pandas.DataFrame)
+        ``(summary_text, summary_dataframe)`` — the rendered table
+        and the raw metrics dataframe.
+
+    """
     # motmetrics' loadtxt accepts "mot15-2D" as a valid format string
     # The type stubs may be overly restrictive
     fmt_string: str = "mot15-2D"

--- a/norfair/tracker.py
+++ b/norfair/tracker.py
@@ -1,3 +1,5 @@
+"""Tracking primitives: ``Tracker``, ``TrackedObject`` and ``Detection``."""
+
 import logging
 import threading
 from collections.abc import Callable, Hashable, Sequence
@@ -20,66 +22,98 @@ logger = logging.getLogger(__name__)
 
 
 class Tracker:
-    """
-    The class in charge of performing the tracking of the detections produced by a detector.
+    """Tracks detections produced by a detector across frames.
 
     Parameters
     ----------
-    distance_function : Union[str, Callable[[Detection, TrackedObject], float]]
-        Function used by the tracker to determine the distance between newly detected objects and the objects that are currently being tracked.
-        This function should take 2 input arguments, the first being a [Detection][norfair.tracker.Detection], and the second a [TrackedObject][norfair.tracker.TrackedObject].
-        It has to return a `float` with the distance it calculates.
-        Some common distances are implemented in [distances][], as a shortcut the tracker accepts the name of these [predefined distances][norfair.distances.get_distance_by_name].
-        Scipy's predefined distances are also accepted. A `str` with one of the available metrics in
+    distance_function : str or Callable[[Detection, TrackedObject], float]
+        Function used by the tracker to determine the distance between newly
+        detected objects and the objects that are currently being tracked.
+        This function should take 2 input arguments, the first being a
+        [Detection][norfair.tracker.Detection], and the second a
+        [TrackedObject][norfair.tracker.TrackedObject]. It has to return a
+        `float` with the distance it calculates.
+
+        Some common distances are implemented in [distances][]; as a shortcut
+        the tracker accepts the name of one of these
+        [predefined distances][norfair.distances.get_distance_by_name]. Scipy's
+        predefined distances are also accepted — pass a `str` with one of the
+        available metrics in
         [`scipy.spatial.distance.cdist`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.cdist.html).
     distance_threshold : float
-        Defines what is the maximum distance that can constitute a match.
-        Detections and tracked objects whose distances are above this threshold won't be matched by the tracker.
+        Maximum distance that can constitute a match. Detections and tracked
+        objects whose distance is above this threshold won't be matched by
+        the tracker.
     hit_counter_max : int, optional
-        Each tracked objects keeps an internal hit counter which tracks how often it's getting matched to a detection,
-        each time it gets a match this counter goes up, and each time it doesn't it goes down.
+        Each tracked object keeps an internal hit counter which tracks how
+        often it gets matched to a detection; each time it gets a match the
+        counter goes up, and each time it doesn't the counter goes down.
 
-        If it goes below 0 the object gets destroyed. This argument defines how large this inertia can grow,
-        and therefore defines how long an object can live without getting matched to any detections, before it is displaced as a dead object, if no ReID distance function is implemented it will be destroyed.
-    initialization_delay : Optional[int], optional
-         Determines how large the object's hit counter must be in order to be considered as initialized, and get returned to the user as a real object.
-         It must be smaller than `hit_counter_max` or otherwise the object would never be initialized.
+        If the counter goes below 0 the object gets destroyed. This argument
+        defines how large this inertia can grow, and therefore how long an
+        object can live without getting matched to any detections before it
+        is displaced as a dead object. If no ReID distance function is
+        provided the object will then be destroyed.
+    initialization_delay : int, optional
+        Determines how large the object's hit counter must be in order to be
+        considered initialized and be returned to the user as a real object.
+        It must be smaller than ``hit_counter_max`` or otherwise the object
+        would never be initialized.
 
-         If set to 0, objects will get returned to the user as soon as they are detected for the first time,
-         which can be problematic as this can result in objects appearing and immediately dissapearing.
+        If set to 0, objects will be returned to the user as soon as they are
+        detected for the first time, which can be problematic because it can
+        result in objects appearing and immediately disappearing.
 
-         Defaults to `hit_counter_max / 2`
+        Defaults to ``hit_counter_max // 2``.
     pointwise_hit_counter_max : int, optional
-        Each tracked object keeps track of how often the points it's tracking have been getting matched.
-        Points that are getting matched (`pointwise_hit_counter > 0`) are said to be live, and points which aren't (`pointwise_hit_counter = 0`)
-        are said to not be live.
+        Each tracked object keeps track of how often the points it is
+        tracking have been getting matched. Points that are getting matched
+        (``pointwise_hit_counter > 0``) are said to be *live*, while points
+        that aren't (``pointwise_hit_counter == 0``) are said to be stale.
 
-        This is used to determine things like which individual points in a tracked object get drawn by [`draw_tracked_objects`][norfair.drawing.draw_tracked_objects] and which don't.
-        This argument defines how large the inertia for each point of a tracker can grow.
+        This is used to determine things like which individual points in a
+        tracked object get drawn by
+        [`draw_points`][norfair.drawing.draw_points] and which don't.
+        This argument defines how large the inertia for each point of a
+        tracker can grow.
     detection_threshold : float, optional
-        Sets the threshold at which the scores of the points in a detection being fed into the tracker must dip below to be ignored by the tracker.
+        Threshold at which point scores in a detection must be above to be
+        considered by the tracker. Any point whose score is at or below this
+        value is ignored.
     filter_factory : FilterFactory, optional
-        This parameter can be used to change what filter the [`TrackedObject`][norfair.tracker.TrackedObject] instances created by the tracker will use.
-        Defaults to [`OptimizedKalmanFilterFactory()`][norfair.filter.OptimizedKalmanFilterFactory]
+        Selects which filter the
+        [`TrackedObject`][norfair.tracker.TrackedObject] instances created by
+        this tracker will use. Defaults to
+        [`OptimizedKalmanFilterFactory()`][norfair.filter.OptimizedKalmanFilterFactory].
     past_detections_length : int, optional
-        How many past detections to save for each tracked object.
-        Norfair tries to distribute these past detections uniformly through the object's lifetime so they're more representative.
-        Very useful if you want to add metric learning to your model, as you can associate an embedding to each detection and access them in your distance function.
-    reid_distance_function: Optional[Callable[["TrackedObject", "TrackedObject"], float]]
-        Function used by the tracker to determine the ReID distance between newly detected trackers and unmatched trackers by the distance function.
+        How many past detections to save for each tracked object. Norfair
+        tries to distribute these past detections uniformly through the
+        object's lifetime so they're more representative. Very useful if you
+        want to add metric learning to your model, because you can associate
+        an embedding to each detection and access them in your distance
+        function.
+    reid_distance_function : Callable[[TrackedObject, TrackedObject], float], optional
+        Function used by the tracker to determine the ReID distance between
+        newly detected trackers and unmatched trackers.
 
-        This function should take 2 input arguments, the first being tracked objects in the initialization phase of type [`TrackedObject`][norfair.tracker.TrackedObject],
-        and the second being tracked objects that have been unmatched of type [`TrackedObject`][norfair.tracker.TrackedObject]. It returns a `float` with the distance it
-        calculates.
-    reid_distance_threshold: float
-        Defines what is the maximum ReID distance that can constitute a match.
+        This function should take 2 input arguments, the first being a
+        tracked object in the initialization phase, and the second being a
+        tracked object that has been unmatched. Both are
+        [`TrackedObject`][norfair.tracker.TrackedObject] instances. It must
+        return a `float` with the distance it calculates.
+    reid_distance_threshold : float, optional
+        Maximum ReID distance that can constitute a match.
 
-        Tracked objects whose distance is above this threshold won't be merged, if they are the oldest tracked object will be maintained
+        Tracked objects whose distance is above this threshold won't be
+        merged. If they are merged, the oldest tracked object is maintained
         with the position of the new tracked object.
-    reid_hit_counter_max: Optional[int]
-        Each tracked object keeps an internal ReID hit counter which tracks how often it's getting recognized by another tracker,
-        each time it gets a match this counter goes up, and each time it doesn't it goes down. If it goes below 0 the object gets destroyed.
-        If used, this argument (`reid_hit_counter_max`) defines how long an object can live without getting matched to any detections, before it is destroyed.
+    reid_hit_counter_max : int, optional
+        Each tracked object keeps an internal ReID hit counter which tracks
+        how often it is getting recognized by another tracker; each time it
+        gets a match this counter goes up, and each time it doesn't it goes
+        down. If it goes below 0 the object is destroyed. When set, this
+        defines how long an object can live without being matched to any
+        detection before it is destroyed.
 
     Notes
     -----
@@ -87,6 +121,7 @@ class Tracker:
     ``update`` on the same instance from multiple threads. However, using
     separate ``Tracker`` instances in different threads is safe — the shared
     ``global_id`` counter is protected by a lock.
+
     """
 
     def __init__(
@@ -163,33 +198,40 @@ class Tracker:
         period: int = 1,
         coord_transformations: CoordinatesTransformation | None = None,
     ) -> list["TrackedObject"]:
-        """
-        Process detections found in each frame.
+        """Process detections found in the current frame.
 
-        The detections can be matched to previous tracked objects or new ones will be created
-        according to the configuration of the Tracker.
-        The currently alive and initialized tracked objects are returned
+        Detections can be matched to previous tracked objects, or new
+        tracked objects will be created according to the configuration of
+        this ``Tracker``. The currently alive and initialized tracked
+        objects are returned.
 
         Parameters
         ----------
-        detections : Optional[List[Detection]], optional
-            A list of [`Detection`][norfair.tracker.Detection] which represent the detections found in the current frame being processed.
+        detections : list[Detection], optional
+            The [`Detection`][norfair.tracker.Detection] instances found in
+            the current frame being processed.
 
-            If no detections have been found in the current frame, or the user is purposely skipping frames to improve video processing time,
-            this argument should be set to None or ignored, as the update function is needed to advance the state of the Kalman Filters inside the tracker.
+            If no detections were found in the current frame, or the user is
+            purposely skipping frames to improve processing time, this
+            argument should be set to ``None`` or omitted — the update
+            function still needs to be called to advance the state of the
+            Kalman filters inside the tracker.
         period : int, optional
-            The user can chose not to run their detector on all frames, so as to process video faster.
-            This parameter sets every how many frames the detector is getting ran,
-            so that the tracker is aware of this situation and can handle it properly.
+            Many users choose not to run their detector on every frame in
+            order to process video faster. This parameter sets how many
+            frames pass between detector invocations, so the tracker is
+            aware and can handle the situation properly.
 
-            This argument can be reset on each frame processed,
-            which is useful if the user is dynamically changing how many frames the detector is skipping on a video when working in real-time.
-        coord_transformations: Optional[CoordinatesTransformation]
-            The coordinate transformation calculated by the [MotionEstimator][norfair.camera_motion.MotionEstimator].
+            It can be reset on each frame processed, which is useful if you
+            are dynamically changing how many frames the detector skips in a
+            real-time video stream.
+        coord_transformations : CoordinatesTransformation, optional
+            The coordinate transformation calculated by the
+            [`MotionEstimator`][norfair.camera_motion.MotionEstimator].
 
         Returns
         -------
-        List[TrackedObject]
+        list[TrackedObject]
             The list of active tracked objects.
 
         Notes
@@ -202,6 +244,7 @@ class Tracker:
           detection is stored internally.
 
         If you need the original detection unchanged, pass a copy.
+
         """
         if coord_transformations is not None and detections is not None:
             for det in detections:
@@ -288,21 +331,25 @@ class Tracker:
 
     @property
     def current_object_count(self) -> int:
-        """Number of active TrackedObjects"""
+        """Number of currently active ``TrackedObject`` instances."""
         return len(self.get_active_objects())
 
     @property
     def total_object_count(self) -> int:
-        """Total number of TrackedObjects initialized in the by this Tracker"""
+        """Total number of ``TrackedObject`` instances ever initialized by this tracker."""
         return self._obj_factory.count
 
     def get_active_objects(self) -> list["TrackedObject"]:
-        """Get the list of active objects
+        """Return the list of currently active tracked objects.
+
+        An object is active if it has finished initializing and its hit
+        counter is still positive.
 
         Returns
         -------
-        List["TrackedObject"]
-            The list of active objects
+        list[TrackedObject]
+            The active tracked objects.
+
         """
         return [
             o
@@ -381,17 +428,29 @@ class Tracker:
         return unmatched_candidates, matched_objects, unmatched_objects
 
     def match_dets_and_objs(self, distance_matrix: np.ndarray, distance_threshold):
-        """Matches detections with tracked_objects from a distance matrix
+        """Match detections with tracked objects from a distance matrix.
 
-        I used to match by minimizing the global distances, but found several
-        cases in which this was not optimal. So now I just match by starting
-        with the global minimum distance and matching the det-obj corresponding
-        to that distance, then taking the second minimum, and so on until we
-        reach the distance_threshold.
+        Instead of minimizing the global distance, this greedy strategy
+        starts with the global minimum entry and matches the det–obj
+        corresponding to that distance, then takes the second minimum, and
+        so on until ``distance_threshold`` is reached.
 
-        This avoids the the algorithm getting cute with us and matching things
-        that shouldn't be matching just for the sake of minimizing the global
-        distance, which is what used to happen
+        This avoids pathological cases where minimizing the global distance
+        forces matches that shouldn't happen just to bring the overall sum
+        down.
+
+        Parameters
+        ----------
+        distance_matrix : np.ndarray
+            A matrix of shape ``(n_detections, n_objects)``.
+        distance_threshold : float
+            Entries greater than or equal to this value are not matched.
+
+        Returns
+        -------
+        tuple[list[int], list[int]]
+            Matched detection and object indices, in matching order.
+
         """
         # NOTE: This implementation is terribly inefficient, but it doesn't
         #       seem to affect the fps at all.
@@ -464,42 +523,50 @@ class _TrackedObjectFactory:
 
 
 class TrackedObject:
-    """
-    The objects returned by the tracker's `update` function on each iteration.
+    """Objects returned by the tracker's ``update`` method on each iteration.
 
     They represent the objects currently being tracked by the tracker.
 
-    Users should not instantiate TrackedObjects manually;
-    the Tracker will be in charge of creating them.
+    Users should not instantiate ``TrackedObject`` manually; the ``Tracker``
+    is in charge of creating them.
 
     Attributes
     ----------
     estimate : np.ndarray
-        Where the tracker predicts the point will be in the current frame based on past detections.
-        A numpy array with the same shape as the detections being fed to the tracker that produced it.
-    id : Optional[int]
-        The unique identifier assigned to this object by the tracker. Set to `None` if the object is initializing.
-    global_id : Optional[int]
-        The globally unique identifier assigned to this object. Set to `None` if the object is initializing
+        Where the tracker predicts the points will be in the current frame
+        based on past detections. A NumPy array with the same shape as the
+        detections being fed to the tracker that produced it.
+    id : int or None
+        The unique identifier assigned to this object by the tracker. Set to
+        ``None`` while the object is initializing.
+    global_id : int or None
+        The globally unique identifier assigned to this object. Set to
+        ``None`` while the object is initializing.
     last_detection : Detection
-        The last detection that matched with this tracked object.
-        Useful if you are storing embeddings in your detections and want to do metric learning, or for debugging.
-    last_distance : Optional[float]
+        The last detection that matched with this tracked object. Useful if
+        you are storing embeddings in your detections and want to do metric
+        learning, or for debugging.
+    last_distance : float or None
         The distance the tracker had with the last object it matched with.
     age : int
         The age of this object measured in number of frames.
-    live_points :
-        A boolean mask with shape `(n_points,)`. Points marked as `True` have recently been matched with detections.
-        Points marked as `False` haven't and are to be considered stale, and should be ignored.
+    live_points : np.ndarray
+        A boolean mask with shape ``(n_points,)``. Points marked as ``True``
+        have recently been matched with detections. Points marked as
+        ``False`` are stale and should be ignored.
 
-        Functions like [`draw_tracked_objects`][norfair.drawing.draw_tracked_objects] use this property to determine which points not to draw.
+        Functions like [`draw_points`][norfair.drawing.draw_points] use this
+        property to determine which points not to draw.
     initializing_id : int
-        On top of `id`, objects also have an `initializing_id` which is the id they are given internally by the `Tracker`;
-        this id is used solely for debugging.
+        On top of ``id``, objects also have an ``initializing_id`` assigned
+        internally by the ``Tracker``; this id is used solely for debugging.
 
-        Each new object created by the `Tracker` starts as an uninitialized `TrackedObject`,
-        which needs to reach a certain match rate to be converted into a full blown `TrackedObject`.
-        `initializing_id` is the id temporarily assigned to `TrackedObject` while they are getting initialized.
+        Each new object created by the ``Tracker`` starts as an
+        uninitialized ``TrackedObject`` which needs to reach a certain match
+        rate before it is converted into a full-fledged tracked object.
+        ``initializing_id`` is the id temporarily assigned to a
+        ``TrackedObject`` while it is being initialized.
+
     """
 
     def __init__(
@@ -577,6 +644,12 @@ class TrackedObject:
             self.update_coordinate_transformation(coord_transformations)
 
     def tracker_step(self):
+        """Advance the internal state of the tracker by one frame.
+
+        Decrements the hit counters, increments the age and steps the
+        Kalman filter prediction forward. Called by the ``Tracker`` once per
+        update cycle.
+        """
         if self.reid_hit_counter is None:
             if self.hit_counter <= 0:
                 self.reid_hit_counter = self.reid_hit_counter_max
@@ -595,51 +668,64 @@ class TrackedObject:
 
     @property
     def hit_counter_is_positive(self):
+        """Whether the hit counter is still non-negative (object is alive)."""
         return self.hit_counter >= 0
 
     @property
     def reid_hit_counter_is_positive(self):
+        """Whether the ReID hit counter is still non-negative (object can still be re-identified)."""
         return self.reid_hit_counter is None or self.reid_hit_counter >= 0
 
     @property
     def estimate_velocity(self) -> np.ndarray:
-        """Get the velocity estimate of the object from the Kalman filter. This velocity is in the absolute coordinate system.
+        """Return the velocity estimate of the object from the Kalman filter.
+
+        The velocity is expressed in the absolute coordinate system.
 
         Returns
         -------
         np.ndarray
-            An array of shape (self.num_points, self.dim_points) containing the velocity estimate of the object on each axis.
+            An array of shape ``(num_points, dim_points)`` containing the
+            velocity estimate of the object on each axis.
+
         """
         return self.filter.x.T.flatten()[self.dim_z :].reshape(-1, self.dim_points)
 
     @property
     def estimate(self) -> np.ndarray:
-        """Get the position estimate of the object from the Kalman filter.
+        """Return the position estimate of the object from the Kalman filter.
 
         Returns
         -------
         np.ndarray
-            An array of shape (self.num_points, self.dim_points) containing the position estimate of the object on each axis.
+            An array of shape ``(num_points, dim_points)`` containing the
+            position estimate of the object on each axis.
+
         """
         return self.get_estimate()
 
     def get_estimate(self, absolute=False) -> np.ndarray:
-        """Get the position estimate of the object from the Kalman filter in an absolute or relative format.
+        """Return the position estimate in either absolute or relative coordinates.
 
         Parameters
         ----------
         absolute : bool, optional
-            If true the coordinates are returned in absolute format, by default False, by default False.
+            If ``True`` return the estimate in absolute coordinates,
+            otherwise return it in the tracker's relative coordinate system.
+            Defaults to ``False``.
 
         Returns
         -------
         np.ndarray
-            An array of shape (self.num_points, self.dim_points) containing the position estimate of the object on each axis.
+            An array of shape ``(num_points, dim_points)`` containing the
+            position estimate of the object on each axis.
 
         Raises
         ------
         ValueError
-            Alert if the coordinates are requested in absolute format but the tracker has no coordinate transformation.
+            If absolute coordinates are requested but the tracker has no
+            coordinate transformation attached.
+
         """
         positions = self.filter.x.T.flatten()[: self.dim_z].reshape(-1, self.dim_points)
         if self.abs_to_rel is None:
@@ -657,24 +743,24 @@ class TrackedObject:
 
     @property
     def live_points(self):
-        # A point is "live" only if it was matched to a detection in the
-        # current frame AND its pointwise hit counter is still positive.
-        # Previously this relied solely on `point_hit_counter > 0`, which
-        # produced stale True values: an unmatched track still reported
-        # live_points=True because tracker_step() only decrements the
-        # counter by one per frame, while hit() could have pushed it well
-        # above 1 (GH#2, tryolabs/norfair#328).
+        """Boolean mask marking which tracked points are live in the current frame.
+
+        A point is live only if it was matched to a detection in the
+        current frame **and** its pointwise hit counter is still positive.
+        """
         return (self.point_hit_counter > 0) & self._point_matched_in_current_frame
 
     def hit(self, detection: "Detection", period: int = 1):
-        """Update tracked object with a new detection
+        """Update this tracked object with a new detection.
 
         Parameters
         ----------
         detection : Detection
-            the new detection matched to this tracked object
+            The new detection matched to this tracked object.
         period : int, optional
-            frames corresponding to the period of time since last update.
+            Frames corresponding to the period of time since the last
+            update. Defaults to ``1``.
+
         """
         self._conditionally_add_to_past_detections(detection)
 
@@ -755,6 +841,7 @@ class TrackedObject:
         )
 
     def __repr__(self):
+        """Return a human-readable representation of this tracked object."""
         if self.last_distance is None:
             placeholder_text = "\033[1mObject_{}\033[0m(age: {}, hit_counter: {}, last_distance: {}, init_id: {})"
         else:
@@ -768,11 +855,11 @@ class TrackedObject:
         )
 
     def _conditionally_add_to_past_detections(self, detection):
-        """Adds detections into (and pops detections away) from `past_detections`
+        """Maintain the rolling buffer of past detections for this object.
 
-        It does so by keeping a fixed amount of past detections saved into each
-        TrackedObject, while maintaining them distributed uniformly through the object's
-        lifetime.
+        Keeps a fixed number of past detections saved in each
+        ``TrackedObject`` while distributing them uniformly through the
+        object's lifetime.
 
         Note
         ----
@@ -795,7 +882,7 @@ class TrackedObject:
                 self.past_detections.append(detection)
 
     def merge(self, tracked_object):
-        """Merge with a not yet initialized TrackedObject instance"""
+        """Merge another (not-yet-initialized) ``TrackedObject`` into this one."""
         self.reid_hit_counter = None
         self.hit_counter = self.initial_period * 2
         self.point_hit_counter = tracked_object.point_hit_counter
@@ -820,49 +907,62 @@ class TrackedObject:
     def update_coordinate_transformation(
         self, coordinate_transformation: CoordinatesTransformation | None
     ):
+        """Attach (or refresh) the abs→rel converter from a new coordinate transformation."""
         if coordinate_transformation is not None:
             self.abs_to_rel = coordinate_transformation.abs_to_rel
 
     def _acquire_ids(self):
+        """Assign a concrete ``id`` and ``global_id`` from the factory."""
         self.id, self.global_id = self._obj_factory.get_ids()
 
 
 class Detection:
-    """Detections returned by the detector must be converted to a `Detection` object before being used by Norfair.
+    """A single detection produced by a detector, prepared for use by Norfair.
+
+    Detections returned by the detector must be converted to a ``Detection``
+    object before being passed to the ``Tracker``.
 
     Parameters
     ----------
     points : np.ndarray
-        Points detected. Must be a rank 2 array with shape `(n_points, n_dimensions)`.
-    scores : np.ndarray, optional
-        An array of length `n_points` which assigns a score to each of the points defined in `points`.
+        Points detected. Must be a rank-2 array with shape
+        ``(n_points, n_dimensions)``.
+    scores : np.ndarray or float, optional
+        A score per point, or a single scalar score applied to every point.
+        When an array is given, its length must match ``n_points``.
 
-        This is used to inform the tracker of which points to ignore;
-        any point with a score below `detection_threshold` will be ignored.
+        This is used to inform the tracker which points to ignore: any
+        point with a score at or below ``detection_threshold`` is skipped.
 
-        This useful for cases in which detections don't always have every point present, as is often the case in pose estimators.
+        Useful when detections don't always have every point present, as
+        is often the case in pose estimators.
     data : Any, optional
-        The place to store any extra data which may be useful when calculating the distance function.
-        Anything stored here will be available to use inside the distance function.
+        A place to store any extra data which may be useful when calculating
+        the distance function. Anything stored here will be available to use
+        inside the distance function.
 
-        This enables the development of more interesting trackers which can do things like assign an appearance embedding to each
-        detection to aid in its tracking.
+        This enables more interesting trackers that, for instance, attach an
+        appearance embedding to each detection to aid in tracking.
     label : Hashable, optional
-        When working with multiple classes the detection's label can be stored to be used as a matching condition when associating
-        tracked objects with new detections. Label's type must be hashable for drawing purposes.
+        When working with multiple classes, the detection's label can be
+        stored to be used as a matching condition when associating tracked
+        objects with new detections. The label's type must be hashable for
+        drawing purposes.
     embedding : Any, optional
-        The embedding for the reid_distance.
+        An embedding used by the ReID distance function, if any.
 
     Attributes
     ----------
     points : np.ndarray
         The detection points, validated to shape ``(n_points, n_dimensions)``.
     absolute_points : np.ndarray
-        Starts as a copy of ``points``. When ``coord_transformations`` is passed
-        to :meth:`Tracker.update`, this is overwritten with absolute coordinates.
-    age : Optional[int]
+        Starts as a copy of ``points``. When ``coord_transformations`` is
+        passed to [`Tracker.update`][norfair.tracker.Tracker.update], this
+        is overwritten with absolute coordinates.
+    age : int or None
         Set by the tracker to the matched ``TrackedObject``'s age when the
-        detection is stored as a past detection.  ``None`` until then.
+        detection is stored as a past detection. ``None`` until then.
+
     """
 
     def __init__(
@@ -895,6 +995,15 @@ class Detection:
     def update_coordinate_transformation(
         self, coordinate_transformation: CoordinatesTransformation
     ):
+        """Rewrite ``absolute_points`` into absolute coordinates.
+
+        Parameters
+        ----------
+        coordinate_transformation : CoordinatesTransformation
+            Transformation used to map relative points into the absolute
+            reference frame. When ``None``, this is a no-op.
+
+        """
         if coordinate_transformation is not None:
             self.absolute_points = coordinate_transformation.rel_to_abs(
                 self.absolute_points

--- a/norfair/utils.py
+++ b/norfair/utils.py
@@ -1,3 +1,5 @@
+"""Miscellaneous helpers: point validation, terminal sizing, warnings."""
+
 import os
 from collections.abc import Sequence
 from functools import cache
@@ -10,6 +12,12 @@ from rich.table import Table
 
 
 def validate_points(points: np.ndarray) -> np.ndarray:
+    """Normalize ``points`` to ``(n_points, n_dimensions)`` shape.
+
+    A 1-D array is interpreted as a single point and reshaped to have
+    one row; anything with more than two dimensions is rejected via
+    :func:`raise_detection_error_message`.
+    """
     # If the user is tracking only a single point, reformat it slightly.
     if len(points.shape) == 1:
         points = points[np.newaxis, ...]
@@ -19,6 +27,7 @@ def validate_points(points: np.ndarray) -> np.ndarray:
 
 
 def raise_detection_error_message(points):
+    """Raise a ``ValueError`` describing a malformed ``Detection.points``."""
     message = "\n[red]INPUT ERROR:[/red]\n"
     message += f"Each `Detection` object should have a property `points` of shape (n_points, n_dimensions), not {points.shape}. Check your `Detection` list creation code.\n"
     message += "You can read the documentation for the `Detection` class here:\n"
@@ -27,7 +36,7 @@ def raise_detection_error_message(points):
 
 
 def print_objects_as_table(tracked_objects: Sequence):
-    """Used for helping in debugging"""
+    """Pretty-print a table summarizing ``tracked_objects`` for debugging."""
     print()
     console = Console()
     table = Table(show_header=True, header_style="bold magenta")
@@ -48,6 +57,11 @@ def print_objects_as_table(tracked_objects: Sequence):
 
 
 def get_terminal_size(default: tuple[int, int] = (80, 24)) -> tuple[int, int]:
+    """Return the terminal ``(columns, lines)``, falling back to ``default``.
+
+    Tries stdin, stdout and stderr in order, returning the first
+    successful query.
+    """
     columns, lines = default
     for fd in range(0, 3):  # First in order 0=Std In, 1=Std Out, 2=Std Error
         try:
@@ -59,7 +73,7 @@ def get_terminal_size(default: tuple[int, int] = (80, 24)) -> tuple[int, int]:
 
 
 def get_cutout(points, image):
-    """Returns a rectangular cut-out from a set of points on an image"""
+    """Return the axis-aligned bounding-box cutout of ``points`` in ``image``."""
     max_x = int(max(points[:, 0]))
     min_x = int(min(points[:, 0]))
     max_y = int(max(points[:, 1]))
@@ -68,7 +82,15 @@ def get_cutout(points, image):
 
 
 class DummyOpenCVImport:
+    """Placeholder that raises ``ImportError`` when OpenCV is missing.
+
+    Installed as ``cv2`` when the real module cannot be imported, so
+    the first attribute access from a video feature raises a clear
+    error describing how to install the optional dependency.
+    """
+
     def __getattr__(self, name):
+        """Raise ``ImportError`` prompting the user to install OpenCV."""
         raise ImportError(
             r"""[bold red]Missing dependency:[/bold red] You are trying to use Norfair's video features. However, OpenCV is not installed.
 
@@ -77,7 +99,14 @@ Please, make sure there is an existing installation of OpenCV or install Norfair
 
 
 class DummyMOTMetricsImport:
+    """Placeholder that raises ``ImportError`` when ``motmetrics`` is missing.
+
+    Used in the same way as :class:`DummyOpenCVImport` to gate the
+    metrics extra.
+    """
+
     def __getattr__(self, name):
+        """Raise ``ImportError`` prompting the user to install the metrics extra."""
         raise ImportError(
             r"""[bold red]Missing dependency:[/bold red] You are trying to use Norfair's metrics features without the required dependencies.
 
@@ -88,7 +117,5 @@ Please, install Norfair with `pip install norfair-enough\[metrics]`, or `pip ins
 # lru_cache will prevent re-run the function if the message is the same
 @cache
 def warn_once(message):
-    """
-    Write a warning message only once.
-    """
+    """Emit ``message`` via ``logging.warning`` at most once per process."""
     warning(message)

--- a/norfair/video.py
+++ b/norfair/video.py
@@ -1,3 +1,5 @@
+"""Video I/O helpers: frame iteration, display, and output writing."""
+
 import contextlib
 import os
 import time
@@ -25,57 +27,63 @@ from .utils import get_terminal_size
 
 
 def _get_fourcc(codec: str) -> int:
-    """Helper to get VideoWriter fourcc code with proper typing."""
+    """Return the integer fourcc code for ``codec``."""
     return cv2.VideoWriter_fourcc(*codec)  # type: ignore[attr-defined]
 
 
 class Video:
-    """
-    Class that provides a simple and pythonic way to interact with video.
+    """Simple pythonic wrapper around an OpenCV video source and sink.
 
-    It returns regular OpenCV frames which enables the usage of the huge number of tools OpenCV provides to modify images.
+    Yields raw OpenCV frames so the full OpenCV toolbox is available
+    for frame-level processing, while taking care of capture setup,
+    progress-bar rendering and writer initialization.
 
     Parameters
     ----------
-    camera : Optional[int], optional
-        An integer representing the device id of the camera to be used as the video source.
-
-        Webcams tend to have an id of `0`. Arguments `camera` and `input_path` can't be used at the same time, one must be chosen.
-    input_path : Optional[str], optional
-        A string consisting of the path to the video file to be used as the video source.
-
-        Arguments `camera` and `input_path` can't be used at the same time, one must be chosen.
+    camera : int, optional
+        Device id of the camera to read from. Webcams typically use
+        ``0``. Mutually exclusive with ``input_path``.
+    input_path : str, optional
+        Path to the video file to read. Mutually exclusive with
+        ``camera``.
     output_path : str, optional
-        The path to the output video to be generated.
-        Can be a folder were the file will be created or a full path with a file name.
-    output_fps : Optional[float], optional
-        The frames per second at which to encode the output video file.
-
-        If not provided it is set to be equal to the input video source's fps.
-        This argument is useful when using live video cameras as a video source,
-        where the user may know the input fps,
-        but where the frames are being fed to the output video at a rate that is lower than the video source's fps,
-        due to the latency added by the detector.
+        Where the output video should be written. May be a directory
+        (an output filename is then auto-generated) or a full file
+        path.
+    output_fps : float, optional
+        Frames per second for the output file. Defaults to the input
+        source's fps. This is useful with live cameras when the
+        effective processing rate is lower than the camera's native
+        rate.
     label : str, optional
-        Label to add to the progress bar that appears when processing the current video.
-    output_fourcc : Optional[str], optional
-        OpenCV encoding for output video file.
-        By default we use `mp4v` for `.mp4` and `XVID` for `.avi`. This is a combination that works on most systems but
-        it results in larger files. To get smaller files use `avc1` or `H264` if available.
-        Notice that some fourcc are not compatible with some extensions.
+        Optional label appended to the progress-bar description.
+    output_fourcc : str, optional
+        OpenCV codec for the output file. Defaults to ``"mp4v"`` for
+        ``.mp4`` outputs and ``"XVID"`` for ``.avi``. Try ``"avc1"``
+        or ``"H264"`` for smaller files when available.
     output_extension : str, optional
-        File extension used for the output video. Ignored if `output_path` is not a folder.
+        File extension used when ``output_path`` is a directory.
 
     Examples
     --------
-    >>> with Video(input_path="video.mp4") as video:
-    ...     for frame in video:
-    ...         # << Your modifications to the frame would go here >>
-    ...         video.write(frame)
+    Read, process and write a video::
 
-    The context manager ensures that video resources are released even if the
-    loop is interrupted early. Iterating without ``with`` still works — resources
-    are released when the iterator is exhausted or when ``close()`` is called.
+        >>> with Video(input_path="video.mp4") as video:
+        ...     for frame in video:
+        ...         # << your frame processing goes here >>
+        ...         video.write(frame)
+
+    The context manager releases the underlying ``VideoCapture`` and
+    ``VideoWriter`` even if the loop is interrupted. Iterating without
+    ``with`` also works — resources are freed when the iterator is
+    exhausted or when :meth:`close` is called.
+
+    Raises
+    ------
+    ValueError
+        If neither or both of ``camera`` / ``input_path`` are
+        supplied, or if ``camera`` is not an ``int``.
+
     """
 
     def __init__(
@@ -88,6 +96,7 @@ class Video:
         output_fourcc: str | None = None,
         output_extension: str = "mp4",
     ):
+        """Open the capture and set up the progress bar."""
         self.camera = camera
         self.input_path = input_path
         self.output_path = output_path
@@ -168,9 +177,11 @@ class Video:
         )
 
     def __enter__(self):
+        """Return ``self`` so ``Video`` can be used in a ``with`` block."""
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        """Release video resources when leaving a ``with`` block."""
         self.close()
         return False
 
@@ -193,6 +204,18 @@ class Video:
 
     # This is a generator, note the yield keyword below.
     def __iter__(self):
+        """Yield successive OpenCV frames from the underlying capture.
+
+        The progress bar is updated for every frame. When the
+        generator is exhausted (or the consumer loop exits for any
+        reason), :meth:`close` is invoked to release resources.
+
+        Raises
+        ------
+        RuntimeError
+            If the ``Video`` has already been closed.
+
+        """
         if self._closed:
             raise RuntimeError("Cannot iterate over a closed Video")
         try:
@@ -215,11 +238,15 @@ class Video:
             self.close()
 
     def _fail(self, msg: str):
+        """Raise a ``RuntimeError`` with ``msg``."""
         raise RuntimeError(msg)
 
     def write(self, frame: np.ndarray) -> int:
-        """
-        Write one frame to the output video.
+        """Write one frame to the output video.
+
+        Lazily initializes the underlying ``cv2.VideoWriter`` on the
+        first call, using ``frame``'s shape to determine the output
+        resolution.
 
         Parameters
         ----------
@@ -230,6 +257,7 @@ class Video:
         -------
         int
             The key code from ``cv2.waitKey(1)``.
+
         """
         if self.output_video is None:
             # The user may need to access the output file path on their code
@@ -251,22 +279,25 @@ class Video:
         return cv2.waitKey(1)
 
     def show(self, frame: np.ndarray, downsample_ratio: float = 1.0) -> int:
-        """
-        Display a frame through a GUI. Usually used inside a video inference loop to show the output video.
+        """Display ``frame`` in a GUI window.
+
+        Typically called inside a video-inference loop to preview the
+        output.
 
         Parameters
         ----------
         frame : np.ndarray
             The OpenCV frame to be displayed.
         downsample_ratio : float, optional
-            How much to downsample the frame being show.
-
-            Useful when streaming the GUI video display through a slow internet connection using something like X11 forwarding on an ssh connection.
+            Factor by which to downsample the frame before displaying.
+            Useful when streaming the GUI video display over a slow
+            connection (e.g. X11 forwarding over SSH).
 
         Returns
         -------
         int
             The key code from ``cv2.waitKey(1)``.
+
         """
         # Resize to lower resolution for faster streaming over slow connections
         if downsample_ratio != 1.0:
@@ -281,15 +312,17 @@ class Video:
         return cv2.waitKey(1)
 
     def get_output_file_path(self) -> str:
-        """
-        Calculate the output path being used in case you are writing your frames to a video file.
+        """Return the resolved output-file path for written frames.
 
-        Useful if you didn't set `output_path`, and want to know what the autogenerated output file path by Norfair will be.
+        When ``output_path`` is a directory, Norfair auto-generates a
+        filename based on the input source. This method returns that
+        resolved path so callers can locate the rendered video.
 
         Returns
         -------
         str
-            The path to the file.
+            The absolute (or relative) path to the output file.
+
         """
         if not os.path.isdir(self.output_path):
             return self.output_path
@@ -303,6 +336,30 @@ class Video:
         return os.path.join(self.output_path, file_name)
 
     def get_codec_fourcc(self, filename: str) -> str:
+        """Resolve the fourcc codec name to use when writing ``filename``.
+
+        Returns :attr:`output_fourcc` when set; otherwise derives a
+        default from ``filename``'s extension (``"XVID"`` for
+        ``.avi``, ``"mp4v"`` for ``.mp4``).
+
+        Parameters
+        ----------
+        filename : str
+            Destination file whose extension is used for codec
+            auto-selection.
+
+        Returns
+        -------
+        str
+            Name of the fourcc codec to feed to
+            :class:`cv2.VideoWriter`.
+
+        Raises
+        ------
+        RuntimeError
+            If no codec can be resolved from ``filename``.
+
+        """
         if self.output_fourcc is not None:
             return self.output_fourcc
 
@@ -322,7 +379,7 @@ class Video:
             raise RuntimeError("Unreachable")
 
     def abbreviate_description(self, description: str) -> str:
-        """Conditionally abbreviate description so that progress bar fits in small terminals"""
+        """Shorten ``description`` so the progress bar fits small terminals."""
         terminal_columns, _ = get_terminal_size()
         space_for_description = (
             int(terminal_columns) - 25
@@ -334,9 +391,34 @@ class Video:
 
 
 class VideoFromFrames:
+    """Iterate over an MOT-style dataset that stores frames as images.
+
+    Reads ``seqinfo.ini`` to determine frame count, resolution and
+    file-naming convention, then yields successive frames via the
+    iterator protocol. Optionally encodes the frames into an ``.mp4``
+    file alongside the iteration via :meth:`update`.
+
+    Parameters
+    ----------
+    input_path : str
+        Path to the MOT sequence directory (containing
+        ``seqinfo.ini``).
+    save_path : str, optional
+        Directory where the rendered ``.mp4`` is written. A nested
+        ``videos/`` folder is created if ``make_video`` is ``True``.
+    information_file : metrics.InformationFile, optional
+        Pre-parsed ``seqinfo.ini`` wrapper. Loaded from ``input_path``
+        when not provided.
+    make_video : bool, optional
+        If ``True`` (the default), open a ``cv2.VideoWriter`` into
+        which :meth:`update` will write frames.
+
+    """
+
     def __init__(
         self, input_path, save_path=".", information_file=None, make_video=True
     ):
+        """Parse ``seqinfo.ini`` and optionally open the output writer."""
         if information_file is None:
             information_file = metrics.InformationFile(
                 file_path=os.path.join(input_path, "seqinfo.ini")
@@ -376,10 +458,12 @@ class VideoFromFrames:
         self.image_directory = str(dir_val) if not isinstance(dir_val, str) else dir_val
 
     def __iter__(self):
+        """Reset the frame counter and return ``self`` as an iterator."""
         self.frame_number = 1
         return self
 
     def __next__(self):
+        """Return the next image frame from the sequence."""
         if self.frame_number <= self.length:
             frame_path = os.path.join(
                 self.input_path,
@@ -392,6 +476,7 @@ class VideoFromFrames:
         raise StopIteration()
 
     def update(self, frame):
+        """Append ``frame`` to the output video and release on the last frame."""
         self.video.write(frame)
         cv2.waitKey(1)
 


### PR DESCRIPTION
Audits and updates the numpy-style docstrings across the `norfair/` package so they align with current APIs and mkdocstrings rendering.

Bead: ne-3av

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Dokumentation

* **Dokumentation**
  * Umfassende Erweiterung der Dokumentation in der gesamten Bibliothek mit präziseren Beschreibungen von Verhalten, Parametern und erwarteten Ein- und Ausgaben.
  * Verbesserte Klarheit bei Verwendungsbeispielen, Typdefinitionen und Methodensemantiken für besseres Benutzerverständnis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->