### PR TITLE
chore: apply code review nitpicks

### DIFF
--- a/norfair/camera_motion.py
+++ b/norfair/camera_motion.py
@@ -121,7 +121,11 @@ class TranslationTransformationGetter(TransformationGetter):
 
         flow_mode = unique_flows[max_index]
 
-        with contextlib.suppress(TypeError):
+        # Accumulate against the previously stored mode so we report the total
+        # translation since the first frame. On the very first call `self.data`
+        # is still None and there is nothing to accumulate against — leave the
+        # freshly computed mode untouched.
+        if self.data is not None:
             flow_mode += self.data
 
         if update_prvs:

--- a/norfair/distances.py
+++ b/norfair/distances.py
@@ -123,7 +123,14 @@ class ScalarDistance(Distance):
             for o, obj in enumerate(objects):
                 if candidate.label != obj.label:
                     if (candidate.label is None) or (obj.label is None):
-                        logger.warning("There are detections with and without label!")
+                        logger.warning(
+                            "Label mismatch between candidate and tracked "
+                            "object: candidate.label=%r, object.label=%r. "
+                            "Mixing labelled and unlabelled inputs prevents "
+                            "these pairs from ever matching.",
+                            candidate.label,
+                            obj.label,
+                        )
                     continue
                 distance = self.distance_function(candidate, obj)
                 distance_matrix[c, o] = distance

--- a/norfair/drawing/color.py
+++ b/norfair/drawing/color.py
@@ -253,8 +253,14 @@ def parse_color(color_like: ColorLike) -> ColorType:
     if isinstance(color_like, str):
         if color_like.startswith("#"):
             return hex_to_bgr(color_like)
-        else:
+        try:
             return getattr(Color, color_like)
+        except AttributeError as exc:
+            raise ValueError(
+                f"Unknown color name {color_like!r}. Pass a 6-digit hex "
+                f"string like '#ff0000', a BGR tuple, or one of the names "
+                f"defined in norfair.drawing.Color."
+            ) from exc
     # color_like is already a ColorType tuple at this point
     # Ensure it's properly typed as tuple[int, int, int]
     return (int(color_like[0]), int(color_like[1]), int(color_like[2]))

--- a/norfair/drawing/drawer.py
+++ b/norfair/drawing/drawer.py
@@ -146,7 +146,7 @@ class Drawer:
     def rectangle(
         cls,
         frame: np.ndarray,
-        points: Sequence[tuple[int, int]],
+        points: Sequence[tuple[int, int]] | np.ndarray,
         color: ColorType | None = None,
         thickness: int | None = None,
     ) -> np.ndarray:
@@ -157,8 +157,11 @@ class Drawer:
         ----------
         frame : np.ndarray
             The OpenCV frame to draw on. Modified in place.
-        points : Sequence[Tuple[int, int]]
+        points : Sequence[Tuple[int, int]] | np.ndarray
             Points describing the rectangle in the format `[[x0, y0], [x1, y1]]`.
+            May be passed as a nested sequence or as a ``(2, 2)`` numpy array —
+            both forms are normalised to plain ``(int, int)`` tuples before
+            being handed to OpenCV.
         color : Optional[ColorType], optional
             Color of the lines, by default Black.
         thickness : Optional[int], optional

--- a/norfair/filter.py
+++ b/norfair/filter.py
@@ -44,11 +44,25 @@ class FilterPyKalmanFilterFactory(FilterFactory):
     Parameters
     ----------
     R : float, optional
-        Multiplier for the sensor measurement noise matrix, by default 4.0
+        Multiplier for the sensor measurement noise matrix, by default 4.0.
+        Larger values make the filter trust measurements less and rely more
+        on its own predictions — useful when detections are noisy.
     Q : float, optional
-        Multiplier for the process uncertainty, by default 0.1
+        Multiplier for the process uncertainty, by default 0.1.
+        Larger values let the filter react faster to real motion changes but
+        increase jitter; smaller values produce smoother but laggier tracks.
     P : float, optional
-        Multiplier for the initial covariance matrix estimation, only in the entries that correspond to position (not speed) variables, by default 10.0
+        Multiplier for the initial covariance matrix estimation, only in the
+        entries that correspond to position (not speed) variables, by default
+        10.0.
+
+    Notes
+    -----
+    The generated Kalman filter uses a state vector of length ``2 * dim_z``
+    laid out as ``[pos[0], ..., pos[dim_z-1], vel[0], ..., vel[dim_z-1]]``,
+    where ``dim_z = num_points * dim_points`` is the flattened measurement
+    dimensionality. This layout is assumed by the rest of the tracker and
+    should be preserved when subclassing.
 
     See Also
     --------
@@ -248,15 +262,26 @@ class OptimizedKalmanFilterFactory(FilterFactory):
     Parameters
     ----------
     R : float, optional
-        Multiplier for the sensor measurement noise matrix.
+        Multiplier for the sensor measurement noise matrix. Larger values
+        make the filter trust measurements less — useful when detections
+        are noisy.
     Q : float, optional
-        Multiplier for the process uncertainty.
+        Multiplier for the process uncertainty. Larger values let the filter
+        react faster to real motion changes but increase jitter; smaller
+        values produce smoother but laggier tracks.
     pos_variance : float, optional
         Multiplier for the initial covariance matrix estimation, only in the entries that correspond to position (not speed) variables.
     pos_vel_covariance : float, optional
         Multiplier for the initial covariance matrix estimation, only in the entries that correspond to the covariance between position and speed.
     vel_variance : float, optional
         Multiplier for the initial covariance matrix estimation, only in the entries that correspond to velocity (not position) variables.
+
+    Notes
+    -----
+    The generated filter uses the same state vector layout as
+    [`FilterPyKalmanFilterFactory`][norfair.filter.FilterPyKalmanFilterFactory]:
+    ``[pos[0], ..., pos[dim_z-1], vel[0], ..., vel[dim_z-1]]``, with
+    ``dim_z = num_points * dim_points``.
     """
 
     def __init__(

--- a/norfair/tracker.py
+++ b/norfair/tracker.py
@@ -749,6 +749,12 @@ class TrackedObject:
         It does so by keeping a fixed amount of past detections saved into each
         TrackedObject, while maintaining them distributed uniformly through the object's
         lifetime.
+
+        Note
+        ----
+        This method sets ``detection.age`` on the caller's ``Detection`` object.
+        Callers that retain references to their detections will observe this
+        mutation. See the issue tracker for the plan to make this non-mutating.
         """
         detection.age = self.age
         if self.past_detections_length == 0:

--- a/tests/test_drawing.py
+++ b/tests/test_drawing.py
@@ -53,7 +53,7 @@ class TestParseColor:
         assert parse_color((10, 20, 30)) == (10, 20, 30)
 
     def test_invalid_name_raises(self):
-        with pytest.raises(AttributeError):
+        with pytest.raises(ValueError, match="not_a_color_name"):
             parse_color("not_a_color_name")
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,11 +1,9 @@
 """Test that public API exports are accessible from the top-level package."""
 
-import pytest
-
 
 def test_tracker_exports():
     """Test that tracker classes are exported."""
-    from norfair import Detection, Tracker, TrackedObject
+    from norfair import Detection, TrackedObject, Tracker
 
     assert Detection is not None
     assert Tracker is not None
@@ -223,7 +221,6 @@ def test_distance_function_from_name():
 
 def test_video_context_manager_from_top_level():
     """Test that Video context manager works from top-level import."""
-    from unittest.mock import patch
 
     from norfair import Video
 


### PR DESCRIPTION
## Summary

Applies low-severity polish items surfaced by the 2026-04 full code review (pass 1 of the follow-up cleanup).

- **tracker**: document `Detection.age` mutation in `_conditionally_add_to_past_detections` docstring so callers retaining references know the field changes under them (tracked in #47 for a non-mutating fix)
- **distances**: `ScalarDistance` now includes both `candidate.label` and `object.label` in its label-mismatch warning so users can actually debug mixed-label inputs
- **filter**: expand both `FilterPyKalmanFilterFactory` and `OptimizedKalmanFilterFactory` class docstrings with R/Q tuning guidance (when to use larger vs. smaller values) and a `Notes` section documenting the state vector layout `[pos[0..dim_z-1], vel[0..dim_z-1]]` that subclasses must preserve
- **drawing/color**: `parse_color` now raises `ValueError` with a helpful message pointing at hex strings, BGR tuples, and `norfair.drawing.Color` instead of bubbling up an opaque `AttributeError` — test updated to match
- **drawing/drawer**: widen `Drawer.rectangle`'s `points` parameter to `Sequence[tuple[int, int]] | np.ndarray` so numpy coordinate arrays type-check cleanly (they already worked at runtime)
- **camera_motion**: replace `contextlib.suppress(TypeError)` around the first-frame accumulate with an explicit `self.data is not None` check plus comment — the suppress was silently swallowing *any* TypeError, making real bugs invisible

Based on `fix/test-init-trailing-newline` so the nitpicks land cleanly while #34 is still waiting for admin-merge. Will rebase onto `main` after #34 lands.

## Test plan

- [x] `uv run --with ruff ruff format norfair/` — no changes
- [x] `uv run --with ruff ruff check norfair/` — all checks passed
- [x] `uv run --no-sync python -m pytest -x -q` — 129 passed
- [ ] CI green on the PR
- [ ] CodeRabbit review clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rechteck-Zeichnung akzeptiert nun auch NumPy-Arrays als Eingabe.

* **Bug Fixes**
  * Klarere Fehlermeldung bei ungültigen Farbwerten mit Anleitung zu zulässigen Formaten.
  * Präzisere Warnmeldung bei Konflikten zwischen beschrifteten und unbeschrifteten Objekten.

* **Documentation**
  * Erweiterte Hinweise zu Kalman-Filter-Parametern und Zustandsvektor-Layout.
  * Klarstellung zum Nebeneffekt beim Hinzufügen vergangener Detektionen.

* **Tests**
  * Erwartetes Fehlverhalten für ungültige Farbnamen nun als ValueError getestet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->