### PR TITLE
fix: add /latest/ alias for /dev/ and redirect root to /latest/

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,5 +36,5 @@ jobs:
         run: uv sync --locked --group docs
       - name: Deploy dev docs
         run: |
-          uv run mike deploy --push dev
-          uv run mike set-default --push dev
+          uv run mike deploy --push -u dev latest
+          uv run mike set-default --push latest

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,7 +60,7 @@ plugins:
 extra:
   version:
     provider: mike
-    default: dev
+    default: latest
 
 markdown_extensions:
     - toc:


### PR DESCRIPTION
## Summary

- Use `mike deploy --push -u dev latest` to create a `/latest/` alias that points to `/dev/`
- Change `mike set-default` to `latest` so the root URL (`/`) redirects to `/latest/`
- Update `mkdocs.yml` version selector default from `dev` to `latest`

## Behavior after merge

| URL | Resolves to |
|-----|-------------|
| `/` | redirects to `/latest/` |
| `/latest/` | serves the same content as `/dev/` |
| `/dev/` | unchanged, still serves dev docs |

On release, `deploy_docs.py` will reassign the `latest` alias to the release version, which is the existing behavior.

## Test plan

- [ ] Merge and verify the docs workflow runs successfully
- [ ] Confirm `/` redirects to `/latest/`
- [ ] Confirm `/latest/` serves the same content as `/dev/`
- [ ] Confirm `/dev/` still works