### PR TITLE
fix: replace broken /latest/ docs links with /dev/

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Norfair was originally built by [Tryolabs](https://tryolabs.com).
 
 ## Documentation
 
-[Getting started guide](https://akator-de.github.io/norfair-enough/latest/getting_started/).
+[Getting started guide](https://akator-de.github.io/norfair-enough/dev/getting_started/).
 
-[API reference](https://akator-de.github.io/norfair-enough/latest/reference/).
+[API reference](https://akator-de.github.io/norfair-enough/dev/reference/).
 
 ## Examples & demos
 

--- a/norfair/utils.py
+++ b/norfair/utils.py
@@ -31,7 +31,7 @@ def raise_detection_error_message(points):
     message = "\n[red]INPUT ERROR:[/red]\n"
     message += f"Each `Detection` object should have a property `points` of shape (n_points, n_dimensions), not {points.shape}. Check your `Detection` list creation code.\n"
     message += "You can read the documentation for the `Detection` class here:\n"
-    message += "https://akator-de.github.io/norfair-enough/latest/reference/tracker/#norfair.tracker.Detection\n"
+    message += "https://akator-de.github.io/norfair-enough/dev/reference/tracker/#norfair.tracker.Detection\n"
     raise ValueError(message)
 
 


### PR DESCRIPTION
## Summary

- Replace all `/latest/` paths in docs links with `/dev/`, since the docs site only has a `dev` version deployed via mike
- Fixes 404s for the "Getting started guide" and "API reference" links in README.md
- Also fixes the Detection error message link in `norfair/utils.py`

Once a `latest` alias is added via mike (tracked in a parallel PR), these can be switched back to `/latest/` if desired.

## Changed files

- `README.md` — 2 link fixes (getting_started, reference)
- `norfair/utils.py` — 1 link fix (Detection class docs URL in error message)

## Test plan

- [ ] Verify https://akator-de.github.io/norfair-enough/dev/getting_started/ resolves
- [ ] Verify https://akator-de.github.io/norfair-enough/dev/reference/ resolves
- [ ] Verify https://akator-de.github.io/norfair-enough/dev/reference/tracker/#norfair.tracker.Detection resolves

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Dokumentation

* **Dokumentation**
  * Die Dokumentationslinks wurden aktualisiert, um auf die Entwicklerversion statt auf die neueste Version zu verweisen.
  * Die Fehlerausgaben wurden angepasst, um auf die aktuelle Dokumentationsversion zu verweisen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->