### PR TITLE
docs: add disclaimer about upstream demo origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Norfair was originally built by [Tryolabs](https://tryolabs.com).
 
 We provide several examples of how Norfair can be used to add tracking capabilities to different detectors, and also showcase more advanced features. All demos are available in the [`demos/`](https://github.com/akator-de/norfair-enough/tree/main/demos) directory of this repository (originally adapted from [tryolabs/norfair](https://github.com/tryolabs/norfair/tree/master/demos)).
 
+> **Note:** The demo code was originally written in the [tryolabs/norfair](https://github.com/tryolabs/norfair) repository which is no longer actively maintained. Some demos may reference upstream resources that could become unavailable in the future. The demos remain compatible with norfair-enough — just replace `pip install norfair` with `pip install norfair-enough`.
+
 > Note: for ease of reproducibility, the demos provide Dockerfiles. Even though Norfair does not need a GPU, the default configuration of most demos requires a GPU to be able to run the detectors. For this, make sure you install [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) so that your GPU can be shared with Docker.
 >
 > It is possible to run several demos with a CPU, but you will have to modify the scripts or tinker with the installation of their dependencies.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -13,6 +13,8 @@ Models trained for any form of [object detection](https://paperswithcode.com/tas
 - [Openpose](https://github.com/akator-de/norfair-enough/tree/main/demos/openpose)
 - [MMDetection](https://github.com/akator-de/norfair-enough/tree/main/demos/mmdetection)
 
+> **Note:** These demos were originally written for [tryolabs/norfair](https://github.com/tryolabs/norfair) which is no longer actively maintained. Some demos may reference upstream resources that could become unavailable in the future. They remain compatible with norfair-enough — just replace `pip install norfair` with `pip install norfair-enough`.
+
 Any other model trained on one of the supported tasks is also supported and should be easy to integrate with Norfair, regardless of whether it uses Pytorch, TensorFlow, or other.
 
 If you are unsure of which model to use, [Yolov7](https://github.com/WongKinYiu/yolov7) is a good starting point since it's easy to set up and offers models of different sizes pre-trained on object detection and pose estimation.


### PR DESCRIPTION
## Summary

- Add a prominent disclaimer in the **Examples & demos** section of `README.md` noting that demo code originates from the unmaintained [tryolabs/norfair](https://github.com/tryolabs/norfair) repository and that upstream links may become unavailable in the future.
- Add an equivalent disclaimer in `docs/getting_started.md` after the demo integration list.
- Both notes clarify that demos remain compatible with norfair-enough by replacing `pip install norfair` with `pip install norfair-enough`.

No demo links were removed or modified — only the disclaimer was added.

## Test plan

- [ ] Verify README.md renders correctly on GitHub (disclaimer blockquote appears between the demos intro and the Docker note)
- [ ] Verify docs/getting_started.md renders correctly in MkDocs (disclaimer blockquote appears after the detector list)
- [ ] Confirm no existing links were changed or removed