### PR TITLE
fix: close file handles properly in metrics module

### DIFF
--- a/norfair/metrics.py
+++ b/norfair/metrics.py
@@ -177,6 +177,15 @@ class PredictionsTextFile:
         if hasattr(self, "text_file") and self.text_file and not self.text_file.closed:
             self.text_file.close()
 
+    def __enter__(self):
+        """Enter the runtime context and return ``self``."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Exit the runtime context, ensuring the file handle is closed."""
+        self.close()
+        return False
+
     def __del__(self):
         """Ensure the underlying file is closed on garbage collection."""
         self.close()
@@ -390,9 +399,8 @@ class Accumulators:
             os.makedirs(save_path)
 
         metrics_path = os.path.join(save_path, file_name)
-        metrics_file = open(metrics_path, "w+")
-        metrics_file.write(self.summary_text)
-        metrics_file.close()
+        with open(metrics_path, "w") as metrics_file:
+            metrics_file.write(self.summary_text)
 
     def print_metrics(self):
         """Print the rendered ``summary_text`` to stdout."""


### PR DESCRIPTION
## Summary

- **`PredictionsTextFile`**: Added `__enter__` / `__exit__` context manager methods so callers can use `with PredictionsTextFile(...) as f:` to guarantee the file handle is closed on exceptions, `KeyboardInterrupt`, or early returns. The existing `close()` and `__del__` fallbacks are preserved for backward compatibility.
- **`Accumulators.save_metrics`**: Replaced bare `open()` / `.write()` / `.close()` with a `with open(...)` block to ensure the file is closed even if `write()` raises. Also changed the mode from `"w+"` to `"w"` since read-back is not needed.

## Test plan

- [x] `ruff check` passes
- [x] `ruff format` reports no changes
- [x] All 133 existing tests pass (`pytest tests/ -x -q`)

Closes #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactoring**
  * Verbesserte Ressourcenverwaltung und erhöhte Zuverlässigkeit bei Dateivorgängen. Die Metriken-Speicherung nutzt nun Python-Kontextmanager für sichere und zuverlässige Dateibehandlung. Dies garantiert, dass Dateien ordnungsgemäß geschlossen werden, Ressourcen effizient freigegeben werden und das System auch bei unerwarteten Fehlern stabil und zuverlässig läuft. Die Implementierung folgt aktuellen Python-Best-Practices und Standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->