### PR TITLE
fix: guard distance functions against NaN/zero division

### DIFF
--- a/norfair/distances.py
+++ b/norfair/distances.py
@@ -348,7 +348,7 @@ def mean_euclidean(detection: "Detection", tracked_object: "TrackedObject") -> f
     Raises
     ------
     ValueError
-        If either input contains NaN values or if points are empty.
+        If either input is empty or contains non-finite (NaN/Inf) values.
 
     See Also
     --------
@@ -394,7 +394,7 @@ def mean_manhattan(detection: "Detection", tracked_object: "TrackedObject") -> f
     Raises
     ------
     ValueError
-        If either input contains NaN values or if points are empty.
+        If either input is empty or contains non-finite (NaN/Inf) values.
 
     See Also
     --------
@@ -475,9 +475,14 @@ def iou(candidates: np.ndarray, objects: np.ndarray) -> np.ndarray:
         np.clip(bottom_right - top_left, a_min=0, a_max=None), 2
     )
     union = area_candidates[:, None] + area_objects - area_intersection
-    # Guard against zero-area (degenerate) bounding boxes: when the union is
-    # zero the boxes have no area and no overlap, so the distance is 1.
-    iou_values = np.where(union > 0, area_intersection / union, 0.0)
+    # Guard against zero-area (degenerate) bounding boxes: use np.divide with
+    # where= to avoid evaluating the division when union is zero.
+    iou_values = np.divide(
+        area_intersection,
+        union,
+        out=np.zeros_like(area_intersection, dtype=float),
+        where=union > 0,
+    )
     return 1 - iou_values
 
 

--- a/norfair/distances.py
+++ b/norfair/distances.py
@@ -345,12 +345,29 @@ def mean_euclidean(detection: "Detection", tracked_object: "TrackedObject") -> f
     float
         The distance.
 
+    Raises
+    ------
+    ValueError
+        If either input contains NaN values or if points are empty.
+
     See Also
     --------
     [`np.linalg.norm`](https://numpy.org/doc/stable/reference/generated/numpy.linalg.norm.html)
 
     """
-    return np.linalg.norm(detection.points - tracked_object.estimate, axis=1).mean()
+    points = detection.points
+    estimate = tracked_object.estimate
+    if points.size == 0 or estimate.size == 0:
+        raise ValueError(
+            "mean_euclidean received empty points array; "
+            "check that the detection/tracked object has valid points."
+        )
+    if not np.all(np.isfinite(points)) or not np.all(np.isfinite(estimate)):
+        raise ValueError(
+            "mean_euclidean received non-finite (NaN/Inf) input; "
+            "check that the detection/tracked object has valid points."
+        )
+    return np.linalg.norm(points - estimate, axis=1).mean()
 
 
 def mean_manhattan(detection: "Detection", tracked_object: "TrackedObject") -> float:
@@ -374,14 +391,29 @@ def mean_manhattan(detection: "Detection", tracked_object: "TrackedObject") -> f
     float
         The distance.
 
+    Raises
+    ------
+    ValueError
+        If either input contains NaN values or if points are empty.
+
     See Also
     --------
     [`np.linalg.norm`](https://numpy.org/doc/stable/reference/generated/numpy.linalg.norm.html)
 
     """
-    return np.linalg.norm(
-        detection.points - tracked_object.estimate, ord=1, axis=1
-    ).mean()
+    points = detection.points
+    estimate = tracked_object.estimate
+    if points.size == 0 or estimate.size == 0:
+        raise ValueError(
+            "mean_manhattan received empty points array; "
+            "check that the detection/tracked object has valid points."
+        )
+    if not np.all(np.isfinite(points)) or not np.all(np.isfinite(estimate)):
+        raise ValueError(
+            "mean_manhattan received non-finite (NaN/Inf) input; "
+            "check that the detection/tracked object has valid points."
+        )
+    return np.linalg.norm(points - estimate, ord=1, axis=1).mean()
 
 
 def _boxes_area(boxes: np.ndarray) -> np.ndarray:
@@ -442,9 +474,11 @@ def iou(candidates: np.ndarray, objects: np.ndarray) -> np.ndarray:
     area_intersection = np.prod(
         np.clip(bottom_right - top_left, a_min=0, a_max=None), 2
     )
-    return 1 - area_intersection / (
-        area_candidates[:, None] + area_objects - area_intersection
-    )
+    union = area_candidates[:, None] + area_objects - area_intersection
+    # Guard against zero-area (degenerate) bounding boxes: when the union is
+    # zero the boxes have no area and no overlap, so the distance is 1.
+    iou_values = np.where(union > 0, area_intersection / union, 0.0)
+    return 1 - iou_values
 
 
 iou_opt = iou  # deprecated
@@ -599,7 +633,16 @@ def create_normalized_mean_euclidean_distance(
     Callable
         A scalar distance function that can be passed to ``Tracker``.
 
+    Raises
+    ------
+    ValueError
+        If ``height`` or ``width`` is not positive.
+
     """
+    if width <= 0 or height <= 0:
+        raise ValueError(
+            f"width and height must be positive, got width={width}, height={height}"
+        )
 
     def normalized__mean_euclidean_distance(
         detection: "Detection", tracked_object: "TrackedObject"


### PR DESCRIPTION
## Summary

Fixes two related numerical stability bugs in `norfair/distances.py`:

- **iou** (#42): Degenerate bounding boxes (zero area) caused division by zero, producing NaN in the distance matrix. Now uses `np.where(union > 0, ...)` to return distance `1.0` for zero-area boxes instead of NaN.
- **mean_euclidean / mean_manhattan** (#45): NaN or empty inputs silently propagated through the distance computation, eventually triggering a confusing `ValueError` deep in `tracker.py`. Now validates inputs up front with clear error messages identifying the problematic function.
- **create_normalized_mean_euclidean_distance** (#45): Zero or negative `width`/`height` parameters caused `Inf` propagation via in-place division. Now raises `ValueError` at factory creation time.

Closes #42
Closes #45

## Test plan

- [x] All 12 existing `test_distances.py` tests pass
- [x] `ruff check` and `ruff format` clean
- [ ] Verify degenerate bbox `[10, 10, 10, 10]` produces distance 1.0, not NaN
- [ ] Verify `mean_euclidean` with NaN input raises clear `ValueError`
- [ ] Verify `create_normalized_mean_euclidean_distance(0, 100)` raises `ValueError`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Verbesserte Fehlerbehandlung bei Distanzberechnungen: Leere oder nicht-finite Eingaben führen nun zu aussagekräftigen Fehlermeldungen statt zu ungültigen Ergebnissen.
  * Korrekte Behandlung degenerierter Fälle bei Überschneidungsberechnungen, um Divisionen durch Null zu vermeiden; solche Paare liefern nun maximalen Abstand.
  * Validierung von Normalisierungsparametern hinzugefügt: Ungültige Größenwerte führen zu klaren Fehlermeldungen.

* **Dokumentation**
  * Ergänzte Hinweise zu Fehlerbedingungen in den betroffenen Funktionen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->