### PR TITLE
fix: guard against cv2.findHomography() returning None

### DIFF
--- a/norfair/camera_motion.py
+++ b/norfair/camera_motion.py
@@ -5,7 +5,6 @@ translation and homography implementations, and the :class:`MotionEstimator`
 that ties them to OpenCV's sparse optical flow.
 """
 
-import contextlib
 import copy
 import logging
 from abc import ABC, abstractmethod
@@ -285,13 +284,22 @@ class HomographyTransformationGetter(TransformationGetter):
             confidence=self.confidence,
         )
 
+        if homography_matrix is None or points_used is None:
+            logger.warning(
+                "Homography estimation failed for this frame "
+                "(degenerate/collinear/insufficient inlier points)"
+            )
+            if isinstance(self.data, np.ndarray):
+                return True, HomographyTransformation(self.data)
+            else:
+                return True, None
+
         proportion_points_used = np.sum(points_used) / len(points_used)
 
         update_prvs = proportion_points_used < self.proportion_points_used_threshold
 
         if self.data is not None:
-            with contextlib.suppress(TypeError, ValueError):
-                homography_matrix = homography_matrix @ self.data
+            homography_matrix = homography_matrix @ self.data
 
         if update_prvs:
             self.data = homography_matrix


### PR DESCRIPTION
## Summary

- Guard against `cv2.findHomography()` returning `(None, None)` when estimation fails (degenerate, collinear, or insufficient inlier points), which previously caused a crash on `np.sum(points_used)` (line 288)
- Remove the `contextlib.suppress(TypeError, ValueError)` wrapper that silently masked the symptom while allowing `None` to be cached into `self.data`, corrupting subsequent frames
- Remove the now-unused `contextlib` import

Closes #40.

## Test plan

- [x] `uv run ruff check norfair/camera_motion.py` passes
- [x] `uv run ruff format norfair/camera_motion.py` reports no changes
- [x] All 7 camera motion tests pass (`uv run pytest tests/ -q -k "camera or homography or motion"`)
- [ ] Verify behavior with a video containing scene cuts or low-texture frames that trigger `findHomography` failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced robustness for camera motion detection failures with fallback to previously cached transformation data and warning logs
  * Fixed silent error suppression to ensure critical calculation errors are properly reported rather than masked

<!-- end of auto-generated comment: release notes by coderabbit.ai -->