### PR TITLE
fix: guard drawing against NaN/Inf coords and enforce rectangle corner ordering

### DIFF
--- a/norfair/drawing/absolute_grid.py
+++ b/norfair/drawing/absolute_grid.py
@@ -103,9 +103,11 @@ def draw_absolute_grid(
     else:
         points_transformed = coord_transformations.abs_to_rel(points)
 
-    # filter points that are not visible
+    # filter points that are not visible or contain non-finite values (#41)
+    finite_mask = np.all(np.isfinite(points_transformed), axis=1)
     visible_points = points_transformed[
-        (points_transformed <= np.array([w, h])).all(axis=1)
+        finite_mask
+        & (points_transformed <= np.array([w, h])).all(axis=1)
         & (points_transformed >= 0).all(axis=1)
     ]
     for point in visible_points:

--- a/norfair/drawing/draw_boxes.py
+++ b/norfair/drawing/draw_boxes.py
@@ -8,7 +8,7 @@ from norfair.tracker import Detection, TrackedObject
 from norfair.utils import warn_once
 
 from .color import ColorLike, Palette, parse_color
-from .drawer import Drawable, Drawer
+from .drawer import Drawable, Drawer, _safe_int_point  # noqa: F401
 from .utils import _build_text
 
 
@@ -145,6 +145,10 @@ def draw_boxes(
             obj_color = Palette.choose_color(np.random.rand())
         else:
             obj_color = parse_color(color)
+
+        # Skip objects with non-finite coordinates (#41)
+        if not np.all(np.isfinite(d.points)):
+            continue
 
         points = d.points.astype(int)
         if draw_box:

--- a/norfair/drawing/draw_points.py
+++ b/norfair/drawing/draw_points.py
@@ -8,7 +8,7 @@ from norfair.tracker import Detection, TrackedObject
 from norfair.utils import warn_once
 
 from .color import ColorLike, Palette, parse_color
-from .drawer import Drawable, Drawer
+from .drawer import Drawable, Drawer, _safe_int_point
 from .utils import _build_text
 
 
@@ -153,9 +153,12 @@ def draw_points(
         if draw_points:
             for point, live in zip(d.points, d.live_points):
                 if live or not hide_dead_points:
+                    safe_pos = _safe_int_point(point)
+                    if safe_pos is None:
+                        continue
                     Drawer.circle(
                         frame,
-                        tuple(point.astype(int)),  # pyrefly: ignore[bad-argument-type]
+                        safe_pos,
                         radius=radius,
                         color=obj_color,
                         thickness=thickness,
@@ -166,6 +169,9 @@ def draw_points(
             if len(live) > 0:
                 position = live.mean(axis=0)
                 position -= radius
+                text_pos = _safe_int_point(position)
+                if text_pos is None:
+                    continue
                 text = _build_text(
                     d,
                     draw_labels=draw_labels,
@@ -176,7 +182,7 @@ def draw_points(
                 Drawer.text(
                     frame,
                     text,
-                    tuple(position.astype(int)),  # pyrefly: ignore[bad-argument-type]
+                    text_pos,
                     size=text_size,
                     color=obj_text_color,
                     thickness=text_thickness,

--- a/norfair/drawing/drawer.py
+++ b/norfair/drawing/drawer.py
@@ -224,8 +224,8 @@ class Drawer:
 
         # Enforce corner ordering so pt1 is top-left and pt2 is
         # bottom-right regardless of input order (#43).
-        p0 = tuple(points[0])
-        p1 = tuple(points[1])
+        p0 = tuple(map(int, points[0]))
+        p1 = tuple(map(int, points[1]))
         pt1 = (min(p0[0], p1[0]), min(p0[1], p1[1]))
         pt2 = (max(p0[0], p1[0]), max(p0[1], p1[1]))
 

--- a/norfair/drawing/drawer.py
+++ b/norfair/drawing/drawer.py
@@ -16,6 +16,32 @@ except ImportError:
     cv2 = DummyOpenCVImport()
 
 
+def _is_finite_point(point: tuple | np.ndarray) -> bool:
+    """Return ``True`` when every coordinate in *point* is finite.
+
+    NaN and Inf values can appear when the Kalman filter diverges or
+    when a camera-motion estimate is degenerate.  Passing such values
+    to OpenCV drawing primitives via ``.astype(int)`` causes undefined
+    signed-integer wraparound, silent misdrawing, or hard crashes on
+    some platforms.
+    """
+    return bool(np.all(np.isfinite(point)))
+
+
+def _safe_int_point(point: np.ndarray) -> tuple[int, int] | None:
+    """Convert a coordinate array to an ``(int, int)`` tuple, or ``None`` if non-finite.
+
+    Returns
+    -------
+    tuple[int, int] | None
+        The point as a plain ``(int, int)`` tuple, or ``None`` when any
+        coordinate is not finite.
+    """
+    if not _is_finite_point(point):
+        return None
+    return tuple(point.astype(int))
+
+
 class Drawer:
     """Basic drawing primitives used by the higher-level helpers.
 
@@ -55,6 +81,10 @@ class Drawer:
             The ``frame`` passed in (drawn on in place).
 
         """
+        # Guard: skip draw when position contains NaN/Inf (#41)
+        if not _is_finite_point(position):
+            return frame
+
         if radius is None:
             radius = int(max(max(frame.shape) * 0.005, 1))
         if thickness is None:
@@ -116,6 +146,10 @@ class Drawer:
             The ``frame`` passed in (drawn on in place).
 
         """
+        # Guard: skip draw when position contains NaN/Inf (#41)
+        if not _is_finite_point(position):
+            return frame
+
         font_size = (
             size if size is not None else min(max(max(frame.shape) / 4000, 0.5), 1.5)
         )
@@ -179,14 +213,26 @@ class Drawer:
             The ``frame`` passed in (drawn on in place).
 
         """
+        # Guard: skip draw when any corner contains NaN/Inf (#41)
+        if not _is_finite_point(points[0]) or not _is_finite_point(points[1]):
+            return frame
+
         if color is None:
             color = Color.black
         if thickness is None:
             thickness = 1
+
+        # Enforce corner ordering so pt1 is top-left and pt2 is
+        # bottom-right regardless of input order (#43).
+        p0 = tuple(points[0])
+        p1 = tuple(points[1])
+        pt1 = (min(p0[0], p1[0]), min(p0[1], p1[1]))
+        pt2 = (max(p0[0], p1[0]), max(p0[1], p1[1]))
+
         frame = cv2.rectangle(
             frame,
-            tuple(points[0]),
-            tuple(points[1]),
+            pt1,
+            pt2,
             color=color,
             thickness=thickness,
         )
@@ -222,6 +268,10 @@ class Drawer:
             The ``frame`` passed in (drawn on in place).
 
         """
+        # Guard: skip draw when center contains NaN/Inf (#41)
+        if not _is_finite_point(center):
+            return frame
+
         middle_x, middle_y = center
         left = center[0] - radius
         top = center[1] - radius
@@ -273,6 +323,10 @@ class Drawer:
             The ``frame`` passed in (drawn on in place).
 
         """
+        # Guard: skip draw when either endpoint contains NaN/Inf (#41)
+        if not _is_finite_point(start) or not _is_finite_point(end):
+            return frame
+
         return cv2.line(
             frame,
             pt1=start,

--- a/norfair/drawing/path.py
+++ b/norfair/drawing/path.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Sequence
 import numpy as np
 
 from norfair.drawing.color import Palette
-from norfair.drawing.drawer import Drawer
+from norfair.drawing.drawer import Drawer, _safe_int_point
 from norfair.tracker import TrackedObject
 from norfair.utils import warn_once
 
@@ -125,10 +125,12 @@ class Paths:
             points_to_draw = self.get_points_to_draw(obj.estimate)
 
             for point in points_to_draw:
+                safe_pos = _safe_int_point(point)
+                if safe_pos is None:
+                    continue
                 mask = Drawer.circle(
                     mask,
-                    # pyrefly: ignore[bad-argument-type]
-                    position=tuple(point.astype(int)),
+                    position=safe_pos,
                     radius=self.radius,
                     color=color,
                     thickness=self.thickness,
@@ -263,10 +265,12 @@ class AbsolutePaths:
             )
 
             for point in points_rel:
+                safe_pos = _safe_int_point(point)
+                if safe_pos is None:
+                    continue
                 Drawer.circle(
                     frame,
-                    # pyrefly: ignore[bad-argument-type]
-                    position=tuple(point.astype(int)),
+                    position=safe_pos,
                     radius=self.radius,
                     color=color,
                     thickness=self.thickness,
@@ -286,11 +290,14 @@ class AbsolutePaths:
                     else past_points
                 )
                 for j, point in enumerate(past_points_rel):
+                    start = _safe_int_point(last_rel[j])
+                    end = _safe_int_point(point)
+                    if start is None or end is None:
+                        continue
                     Drawer.line(
                         overlay,
-                        # pyrefly: ignore[bad-argument-type]
-                        tuple(last_rel[j].astype(int)),
-                        tuple(point.astype(int)),  # pyrefly: ignore[bad-argument-type]
+                        start,
+                        end,
                         color=color,
                         thickness=self.thickness,
                     )


### PR DESCRIPTION
## Summary

- **Issue #41**: All `Drawer` primitives (`circle`, `text`, `rectangle`, `cross`, `line`) now check coordinates for NaN/Inf before passing them to OpenCV. Non-finite values are silently skipped instead of producing undefined `astype(int)` wraparound or hard crashes. A `_safe_int_point()` helper is provided for callers that convert `np.ndarray` points to `(int, int)` tuples.
- **Issue #43**: `Drawer.rectangle()` now normalises corners via `min`/`max` so `pt1` is always the top-left and `pt2` the bottom-right, regardless of input order. This ensures the rectangle renders correctly even when tracked points are swapped (e.g. after re-identification or merged tracks).
- Callers in `draw_boxes.py`, `draw_points.py`, `path.py`, and `absolute_grid.py` are updated to use the safe conversion helpers at the point-conversion boundary.

Closes #41, closes #43.

## Test plan

- [x] \`uv run ruff check norfair/drawing/\` passes
- [x] \`uv run ruff format norfair/drawing/\` -- no changes
- [x] \`uv run pytest tests/test_drawing.py -x -q\` -- 34 tests pass
- [x] \`uv run pytest tests/ -x -q --ignore=tests/test_utils.py\` -- 133 tests pass (one pre-existing failure in \`test_utils.py\` is unrelated)
- [ ] Manual verification: feed NaN coordinates through drawing helpers and confirm no crash
- [ ] Manual verification: pass swapped rectangle corners and confirm box renders correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Fehlerbehebungen**
  * Verbesserte Robustheit bei der Visualisierung: Zeichenfunktionen filtern nun ungültige Koordinaten (NaN, Infinity) vor dem Rendern, um Fehler und Darstellungsprobleme zu verhindern. Dies betrifft Gitter-, Box-, Punkt- und Pfad-Visualisierungen in der Ausgabe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->