### PR TITLE
fix: add input validation to get_cutout and print_objects_as_table

### DIFF
--- a/norfair/utils.py
+++ b/norfair/utils.py
@@ -46,12 +46,14 @@ def print_objects_as_table(tracked_objects: Sequence):
     table.add_column("Last distance", justify="right")
     table.add_column("Init Id", justify="center")
     for obj in tracked_objects:
+        last_dist = getattr(obj, "last_distance", None)
+        last_dist_str = f"{last_dist:.4f}" if last_dist is not None else "?"
         table.add_row(
-            str(obj.id),
-            str(obj.age),
-            str(obj.hit_counter),
-            f"{obj.last_distance:.4f}",
-            str(obj.initializing_id),
+            str(getattr(obj, "id", "?")),
+            str(getattr(obj, "age", "?")),
+            str(getattr(obj, "hit_counter", "?")),
+            last_dist_str,
+            str(getattr(obj, "initializing_id", "?")),
         )
     console.print(table)
 
@@ -73,11 +75,46 @@ def get_terminal_size(default: tuple[int, int] = (80, 24)) -> tuple[int, int]:
 
 
 def get_cutout(points, image):
-    """Return the axis-aligned bounding-box cutout of ``points`` in ``image``."""
-    max_x = int(max(points[:, 0]))
-    min_x = int(min(points[:, 0]))
-    max_y = int(max(points[:, 1]))
-    min_y = int(min(points[:, 1]))
+    """Return the axis-aligned bounding-box cutout of ``points`` in ``image``.
+
+    Parameters
+    ----------
+    points : np.ndarray
+        Array of shape ``(N, 2)`` with x/y coordinates.
+    image : np.ndarray
+        Image array with at least two spatial dimensions (height, width, ...).
+
+    Returns
+    -------
+    np.ndarray
+        The cropped region.  Returns an empty slice (with a warning) when the
+        bounding box is degenerate (zero width or height after clipping).
+
+    Raises
+    ------
+    ValueError
+        If *points* is empty or does not have shape ``(N, 2)``.
+    """
+    points = np.asarray(points)
+    if points.ndim != 2 or points.shape[1] != 2:
+        raise ValueError(f"points must have shape (N, 2), got {points.shape}")
+    if points.shape[0] == 0:
+        raise ValueError("points array is empty")
+
+    img_h, img_w = image.shape[:2]
+
+    min_x = int(np.clip(np.min(points[:, 0]), 0, img_w))
+    max_x = int(np.clip(np.max(points[:, 0]), 0, img_w))
+    min_y = int(np.clip(np.min(points[:, 1]), 0, img_h))
+    max_y = int(np.clip(np.max(points[:, 1]), 0, img_h))
+
+    if min_x == max_x or min_y == max_y:
+        warning(
+            "get_cutout: degenerate bounding box "
+            f"(x={min_x}..{max_x}, y={min_y}..{max_y}); "
+            "returning empty cutout"
+        )
+
     return image[min_y:max_y, min_x:max_x]
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,92 @@
+"""Tests for norfair.utils -- get_cutout and print_objects_as_table."""
+
+import logging
+
+import numpy as np
+import pytest
+
+from norfair.utils import get_cutout, print_objects_as_table
+
+
+class TestGetCutout:
+    """Tests for get_cutout input validation and clipping."""
+
+    def _make_image(self, h=100, w=200):
+        return np.zeros((h, w, 3), dtype=np.uint8)
+
+    def test_normal_cutout(self):
+        img = self._make_image()
+        points = np.array([[10, 20], [50, 60]])
+        cutout = get_cutout(points, img)
+        assert cutout.shape == (40, 40, 3)
+
+    def test_empty_points_raises(self):
+        img = self._make_image()
+        with pytest.raises(ValueError, match="empty"):
+            get_cutout(np.empty((0, 2)), img)
+
+    def test_wrong_ndim_1d_raises(self):
+        img = self._make_image()
+        with pytest.raises(ValueError, match="shape"):
+            get_cutout(np.array([1, 2]), img)
+
+    def test_wrong_columns_raises(self):
+        img = self._make_image()
+        with pytest.raises(ValueError, match="shape"):
+            get_cutout(np.array([[1, 2, 3]]), img)
+
+    def test_3d_points_raises(self):
+        img = self._make_image()
+        with pytest.raises(ValueError, match="shape"):
+            get_cutout(np.ones((2, 2, 2)), img)
+
+    def test_coords_clipped_to_image_bounds(self):
+        img = self._make_image(h=50, w=50)
+        points = np.array([[-10, -10], [100, 100]])
+        cutout = get_cutout(points, img)
+        assert cutout.shape == (50, 50, 3)
+
+    def test_degenerate_same_point_warns(self, caplog):
+        img = self._make_image()
+        points = np.array([[10, 20], [10, 20]])
+        with caplog.at_level(logging.WARNING):
+            cutout = get_cutout(points, img)
+        assert cutout.size == 0
+        assert "degenerate" in caplog.text
+
+
+class TestPrintObjectsAsTable:
+    """Tests for print_objects_as_table attribute-safety."""
+
+    def _make_obj(self, **kwargs):
+        class _Obj:
+            pass
+
+        o = _Obj()
+        for k, v in kwargs.items():
+            setattr(o, k, v)
+        return o
+
+    def test_full_object(self, capsys):
+        obj = self._make_obj(
+            id=1, age=5, hit_counter=3, last_distance=0.1234, initializing_id=0
+        )
+        print_objects_as_table([obj])
+        out = capsys.readouterr().out
+        assert "1" in out
+
+    def test_missing_attributes_shows_fallback(self, capsys):
+        obj = self._make_obj()
+        print_objects_as_table([obj])
+        out = capsys.readouterr().out
+        assert "?" in out
+
+    def test_partial_attributes(self, capsys):
+        obj = self._make_obj(id=42, age=7)
+        print_objects_as_table([obj])
+        out = capsys.readouterr().out
+        assert "42" in out
+        assert "?" in out
+
+    def test_empty_sequence(self, capsys):
+        print_objects_as_table([])


### PR DESCRIPTION
## Summary

- **`get_cutout`**: Validates that `points` has shape `(N, 2)` and is non-empty before processing. Clips coordinates to image bounds via `np.clip` to prevent silent out-of-bounds slicing. Emits a warning for degenerate (zero-area) bounding boxes instead of silently returning confusing empty arrays.
- **`print_objects_as_table`**: Replaces direct attribute access with `getattr(obj, name, "?")` fallbacks so objects missing expected attributes (e.g. lightweight wrappers or subclasses) render gracefully with `?` placeholders instead of raising opaque `AttributeError`.
- Adds 11 new unit tests covering both functions: shape validation, empty input, out-of-bounds clipping, degenerate windows, full/partial/missing attributes, and empty sequences.

Closes #50

## Test plan

- [x] `get_cutout` rejects empty points array with clear `ValueError`
- [x] `get_cutout` rejects 1-D, wrong-column, and 3-D point arrays
- [x] `get_cutout` clips out-of-bounds coordinates to image dimensions
- [x] `get_cutout` warns on degenerate (zero-area) bounding boxes
- [x] `get_cutout` returns correct cutout for normal input
- [x] `print_objects_as_table` renders full objects correctly
- [x] `print_objects_as_table` shows `?` for completely missing attributes
- [x] `print_objects_as_table` shows `?` for partially missing attributes
- [x] `print_objects_as_table` handles empty sequence without error
- [x] All 143 existing tests continue to pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Fehlerbehebungen
- Verbesserte Robustheit bei der Anzeige von Objektinformationen durch sichere Behandlung fehlender Attribute mit Platzhaltern
- Erweiterte Eingabevalidierung und Überprüfung von Begrenzungsrahmen-Koordinaten zur Vermeidung von Fehlern bei der Bildverarbeitung

## Tests
- Neue Test-Suite für Fehlerbehandlung, Eingabevalidierung und Kantenfall-Szenarien

<!-- end of auto-generated comment: release notes by coderabbit.ai -->