### PR TITLE
fix: correct broken anchor and MediaPipe link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Most tracking demos are showcased with vehicles and pedestrians, but the detecto
 2. [Track both bounding boxes and human keypoints](https://github.com/akator-de/norfair-enough/tree/main/demos/keypoints_bounding_boxes) (multi-class), unifying the detections from a YOLO model and OpenPose.
 3. [Re-identification (ReID)](https://github.com/akator-de/norfair-enough/tree/main/demos/reid) of tracked objects using appearance embeddings. This is a good starting point for scenarios with a lot of occlusion, in which the Kalman filter alone would struggle.
 4. [Accurately track objects even if the camera is moving](https://github.com/akator-de/norfair-enough/tree/main/demos/camera_motion), by estimating camera motion potentially accounting for pan, tilt, rotation, movement in any direction, and zoom.
-5. [Track points in 3D](https://github.com/akator-de/norfair-enough/tree/main/demos/3d_track), using [MediaPipe Objectron](https://google.github.io/mediapipe/solutions/objectron.html).
+5. [Track points in 3D](https://github.com/akator-de/norfair-enough/tree/main/demos/3d_track), using [MediaPipe Objectron](https://github.com/google-ai-edge/mediapipe/blob/master/docs/solutions/objectron.md).
 6. [Tracking of small objects](https://github.com/akator-de/norfair-enough/tree/main/demos/sahi), using [SAHI: Slicing Aided Hyper Inference](https://github.com/obss/sahi).
 
 ### Benchmarking and profiling

--- a/docs/gen_index.py
+++ b/docs/gen_index.py
@@ -12,11 +12,9 @@ with open("README.md") as f:
 content = re.sub(r"\]\(/?docs/", r"](", content)
 # remove "docs" from src fields in html
 content = re.sub(r"src=\"/?docs/", 'src="', content)
-# GitHub and mkdocs slugify headings differently. "Examples & demos" becomes
-# "examples--demos" on GitHub (two dashes around the stripped `&`) but
-# "examples-demos" under mkdocs' default slugify. Rewrite the anchor so the
-# rendered index.md has working in-page links.
-content = re.sub(r"#examples--demos\b", "#examples-demos", content)
+# The toc extension is configured (in mkdocs.yml) with pymdownx.slugs.slugify
+# which preserves the GitHub-style anchor `#examples--demos` for the heading
+# "Examples & demos", so no rewrite is needed here.
 
 # write the index
 with mkdocs_gen_files.open("index.md", "w") as fd:  #


### PR DESCRIPTION
## Summary

- **Broken anchor link on home page**: The `gen_index.py` script was rewriting the `#examples--demos` anchor to `#examples-demos` (single dash), but `pymdownx.slugs.slugify` (configured in `mkdocs.yml`) already preserves the GitHub-style double-dash anchor from the heading "Examples & demos". Removed the incorrect rewrite so the in-page link works on the docs site.

- **Broken MediaPipe Objectron link**: The link to `google.github.io/mediapipe/solutions/objectron.html` returns 404 since Google restructured their docs and deprecated Objectron. Replaced with the archived GitHub docs page at `https://github.com/google-ai-edge/mediapipe/blob/master/docs/solutions/objectron.md`.

## Test plan

- [ ] Verify the `#examples--demos` anchor link works on the rendered docs home page
- [ ] Verify the MediaPipe Objectron link resolves to a valid page
- [ ] Confirm no other anchor links are broken on the docs site

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Dokumentation
* Externe Referenz für die „Track points in 3D"-Demo wurde auf die aktuelle GitHub-basierte Dokumentationspfad aktualisiert.

## Wartung
* Interne Verbesserungen an der Dokumentationsverarbeitung vorgenommen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->