### PR TITLE
tests: comprehensive coverage for utils, drawing, camera_motion

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,10 @@ from norfair.utils import validate_points
 def reset_global_count():
     """Reset TrackedObject global count before each test for isolation."""
     _TrackedObjectFactory.global_count = 0
-    yield
+    try:
+        yield
+    finally:
+        _TrackedObjectFactory.global_count = 0
 
 
 @pytest.fixture

--- a/tests/test_camera_motion.py
+++ b/tests/test_camera_motion.py
@@ -172,9 +172,7 @@ class TestTranslationTransformationGetter:
         # but the getter accumulates. Simulate a second observation:
         _, t2 = getter(base_pts + shift1 + shift2, base_pts)
         # Accumulated shift should be shift1+shift2
-        np.testing.assert_allclose(
-            t2.movement_vector, shift1 + shift2, atol=0.2
-        )
+        np.testing.assert_allclose(t2.movement_vector, shift1 + shift2, atol=0.2)
 
 
 # ---------------------------------------------------------------
@@ -218,7 +216,7 @@ class TestHomographyTransformationGetter:
 
     def test_insufficient_points_returns_none_first_call(self):
         """With fewer than 4 points and no prior data, returns (True, None)."""
-        cv2 = pytest.importorskip("cv2")
+        pytest.importorskip("cv2")
         from norfair.camera_motion import HomographyTransformationGetter
 
         getter = HomographyTransformationGetter()
@@ -231,7 +229,7 @@ class TestHomographyTransformationGetter:
 
     def test_insufficient_points_returns_last_known(self):
         """With fewer than 4 points but prior data, returns last known homography."""
-        cv2 = pytest.importorskip("cv2")
+        pytest.importorskip("cv2")
         from norfair.camera_motion import HomographyTransformationGetter
 
         getter = HomographyTransformationGetter()
@@ -250,13 +248,19 @@ class TestHomographyTransformationGetter:
 
     def test_identity_with_matching_points(self):
         """Identical point sets should yield a near-identity homography."""
-        cv2 = pytest.importorskip("cv2")
+        pytest.importorskip("cv2")
         from norfair.camera_motion import HomographyTransformationGetter
 
         getter = HomographyTransformationGetter()
         pts = np.array(
-            [[10.0, 10.0], [100.0, 10.0], [100.0, 100.0], [10.0, 100.0],
-             [50.0, 50.0], [75.0, 25.0]],
+            [
+                [10.0, 10.0],
+                [100.0, 10.0],
+                [100.0, 100.0],
+                [10.0, 100.0],
+                [50.0, 50.0],
+                [75.0, 25.0],
+            ],
             dtype=np.float32,
         )
         update, transform = getter(pts, pts)
@@ -269,14 +273,20 @@ class TestHomographyTransformationGetter:
 
     def test_known_translation_via_homography(self):
         """A known shift in points should produce a translation-like homography."""
-        cv2 = pytest.importorskip("cv2")
+        pytest.importorskip("cv2")
         from norfair.camera_motion import HomographyTransformationGetter
 
         getter = HomographyTransformationGetter()
         shift = np.array([5.0, -3.0])
         prev_pts = np.array(
-            [[10.0, 10.0], [200.0, 10.0], [200.0, 200.0], [10.0, 200.0],
-             [100.0, 100.0], [50.0, 150.0]],
+            [
+                [10.0, 10.0],
+                [200.0, 10.0],
+                [200.0, 200.0],
+                [10.0, 200.0],
+                [100.0, 100.0],
+                [50.0, 150.0],
+            ],
             dtype=np.float32,
         )
         curr_pts = (prev_pts + shift).astype(np.float32)
@@ -299,7 +309,7 @@ class TestMotionEstimator:
 
     def test_first_frame_near_identity(self):
         """The first call compares the frame against itself, yielding near-identity."""
-        cv2 = pytest.importorskip("cv2")
+        pytest.importorskip("cv2")
         from norfair.camera_motion import MotionEstimator
 
         estimator = MotionEstimator()
@@ -316,7 +326,7 @@ class TestMotionEstimator:
 
     def test_identical_frames_produce_near_identity(self):
         """Two identical frames should produce a near-identity transformation."""
-        cv2 = pytest.importorskip("cv2")
+        pytest.importorskip("cv2")
         from norfair.camera_motion import MotionEstimator
 
         # Use TranslationTransformationGetter for simpler results
@@ -370,7 +380,7 @@ class TestMotionEstimator:
 
     def test_with_mask(self):
         """MotionEstimator should accept an optional mask."""
-        cv2 = pytest.importorskip("cv2")
+        pytest.importorskip("cv2")
         from norfair.camera_motion import MotionEstimator
 
         getter = TranslationTransformationGetter()
@@ -382,13 +392,13 @@ class TestMotionEstimator:
 
         # Should not raise
         estimator.update(frame, mask=mask)
-        result = estimator.update(frame, mask=mask)
+        estimator.update(frame, mask=mask)
         # With identical frames and full mask, we should get a valid transform or None
         # (either is fine; the key is no crash)
 
     def test_draw_flow_flag(self):
         """Setting draw_flow=True should not crash."""
-        cv2 = pytest.importorskip("cv2")
+        pytest.importorskip("cv2")
         from norfair.camera_motion import MotionEstimator
 
         estimator = MotionEstimator(draw_flow=True)
@@ -410,7 +420,7 @@ class TestSparseFlowHelpers:
 
     def test_get_sparse_flow_with_identical_images(self):
         """Sparse flow between identical images should yield near-zero displacement."""
-        cv2 = pytest.importorskip("cv2")
+        pytest.importorskip("cv2")
         from norfair.camera_motion import _get_sparse_flow
 
         rng = np.random.RandomState(0)
@@ -424,7 +434,7 @@ class TestSparseFlowHelpers:
 
     def test_get_sparse_flow_returns_matching_shapes(self):
         """curr_pts and prev_pts should have the same shape."""
-        cv2 = pytest.importorskip("cv2")
+        pytest.importorskip("cv2")
         from norfair.camera_motion import _get_sparse_flow
 
         rng = np.random.RandomState(1)
@@ -439,7 +449,7 @@ class TestSparseFlowHelpers:
 
     def test_calc_optical_flow_basic(self):
         """_calc_optical_flow should return arrays or Nones."""
-        cv2 = pytest.importorskip("cv2")
+        pytest.importorskip("cv2")
         from norfair.camera_motion import _calc_optical_flow
 
         rng = np.random.RandomState(2)

--- a/tests/test_camera_motion.py
+++ b/tests/test_camera_motion.py
@@ -1,6 +1,11 @@
 import numpy as np
+import pytest
 
-from norfair.camera_motion import HomographyTransformation
+from norfair.camera_motion import (
+    HomographyTransformation,
+    TranslationTransformation,
+    TranslationTransformationGetter,
+)
 
 
 def test_homography_1d_point():
@@ -57,3 +62,394 @@ def test_homography_1d_non_identity():
     result = transform.abs_to_rel(point_1d)
     assert result.ndim == 1
     np.testing.assert_allclose(result, np.array([110.0, 220.0]))
+
+
+# ---------------------------------------------------------------
+# TranslationTransformation
+# ---------------------------------------------------------------
+class TestTranslationTransformation:
+    """Tests for TranslationTransformation with various movement vectors."""
+
+    def test_identity_translation(self):
+        """Zero movement vector should leave points unchanged."""
+        t = TranslationTransformation(np.array([0.0, 0.0]))
+        pts = np.array([[10.0, 20.0], [30.0, 40.0]])
+        np.testing.assert_allclose(t.abs_to_rel(pts), pts)
+        np.testing.assert_allclose(t.rel_to_abs(pts), pts)
+
+    def test_nonzero_translation(self):
+        """Non-zero movement vector shifts points correctly."""
+        movement = np.array([5.0, -3.0])
+        t = TranslationTransformation(movement)
+        pts = np.array([[100.0, 200.0]])
+
+        # abs_to_rel adds the movement vector
+        result_rel = t.abs_to_rel(pts)
+        np.testing.assert_allclose(result_rel, np.array([[105.0, 197.0]]))
+
+        # rel_to_abs subtracts the movement vector
+        result_abs = t.rel_to_abs(pts)
+        np.testing.assert_allclose(result_abs, np.array([[95.0, 203.0]]))
+
+    def test_roundtrip(self):
+        """abs_to_rel followed by rel_to_abs should return the original point."""
+        movement = np.array([7.5, -12.3])
+        t = TranslationTransformation(movement)
+        pts = np.array([[42.0, 99.0], [0.0, 0.0], [-10.0, 50.0]])
+        roundtripped = t.rel_to_abs(t.abs_to_rel(pts))
+        np.testing.assert_allclose(roundtripped, pts)
+
+    def test_1d_point(self):
+        """Single 1D point arrays should work (matching HomographyTransformation behavior)."""
+        movement = np.array([3.0, 4.0])
+        t = TranslationTransformation(movement)
+        pt = np.array([10.0, 20.0])
+        np.testing.assert_allclose(t.abs_to_rel(pt), np.array([13.0, 24.0]))
+        np.testing.assert_allclose(t.rel_to_abs(pt), np.array([7.0, 16.0]))
+
+    def test_batch_points(self):
+        """Multiple points should all be translated uniformly."""
+        movement = np.array([1.0, 2.0])
+        t = TranslationTransformation(movement)
+        pts = np.array([[0.0, 0.0], [10.0, 10.0], [20.0, 20.0]])
+        expected_rel = pts + movement
+        expected_abs = pts - movement
+        np.testing.assert_allclose(t.abs_to_rel(pts), expected_rel)
+        np.testing.assert_allclose(t.rel_to_abs(pts), expected_abs)
+
+
+# ---------------------------------------------------------------
+# TranslationTransformationGetter
+# ---------------------------------------------------------------
+class TestTranslationTransformationGetter:
+    """Tests for TranslationTransformationGetter."""
+
+    def test_uniform_flow(self):
+        """When all points move by the same vector, that vector is the mode."""
+        getter = TranslationTransformationGetter(bin_size=0.5)
+        prev_pts = np.array([[10.0, 20.0], [30.0, 40.0], [50.0, 60.0]])
+        shift = np.array([3.0, -2.0])
+        curr_pts = prev_pts + shift
+
+        update_prvs, transform = getter(curr_pts, prev_pts)
+        assert isinstance(transform, TranslationTransformation)
+
+        # With uniform flow the mode matches exactly; all points agree so
+        # proportion_points_used = 1.0, which is >= threshold => no update
+        assert not update_prvs
+
+        # The transform's movement_vector should be the detected shift
+        np.testing.assert_allclose(transform.movement_vector, shift, atol=0.5)
+
+    def test_noisy_flow_triggers_update(self):
+        """When too few points agree, the reference frame should update."""
+        getter = TranslationTransformationGetter(
+            bin_size=0.2, proportion_points_used_threshold=0.9
+        )
+        # 10 points all moving differently so no strong mode
+        rng = np.random.RandomState(42)
+        prev_pts = rng.rand(10, 2) * 100
+        curr_pts = prev_pts + rng.rand(10, 2) * 50  # large random shifts
+
+        update_prvs, transform = getter(curr_pts, prev_pts)
+        assert isinstance(transform, TranslationTransformation)
+        # With random flow, few points share the same bin => update_prvs should be True
+        assert update_prvs
+
+    def test_accumulation_across_calls(self):
+        """The getter accumulates flow across consecutive calls."""
+        getter = TranslationTransformationGetter(bin_size=0.2)
+        base_pts = np.array([[0.0, 0.0], [10.0, 10.0], [20.0, 20.0], [30.0, 30.0]])
+
+        shift1 = np.array([2.0, 0.0])
+        _, t1 = getter(base_pts + shift1, base_pts)
+        np.testing.assert_allclose(t1.movement_vector, shift1, atol=0.2)
+
+        # Second call: another uniform shift on top of the first
+        shift2 = np.array([0.0, 3.0])
+        # The getter expects (curr_pts, prev_pts) relative to whatever reference
+        # frame is active. Since update_prvs was False, the reference didn't change,
+        # but the getter accumulates. Simulate a second observation:
+        _, t2 = getter(base_pts + shift1 + shift2, base_pts)
+        # Accumulated shift should be shift1+shift2
+        np.testing.assert_allclose(
+            t2.movement_vector, shift1 + shift2, atol=0.2
+        )
+
+
+# ---------------------------------------------------------------
+# HomographyTransformation — additional edge cases
+# ---------------------------------------------------------------
+class TestHomographyTransformationExtra:
+    """Additional edge-case tests for HomographyTransformation."""
+
+    def test_roundtrip(self):
+        """abs_to_rel -> rel_to_abs should be the identity."""
+        H = np.array([[2, 0, 5], [0, 3, -7], [0, 0, 1]], dtype=float)
+        t = HomographyTransformation(H)
+        pts = np.array([[1.0, 2.0], [10.0, -5.0], [0.0, 0.0]])
+        roundtripped = t.rel_to_abs(t.abs_to_rel(pts))
+        np.testing.assert_allclose(roundtripped, pts, atol=1e-10)
+
+    def test_scaling_homography(self):
+        """A pure-scaling homography should scale coordinates."""
+        H = np.array([[2, 0, 0], [0, 3, 0], [0, 0, 1]], dtype=float)
+        t = HomographyTransformation(H)
+        pt = np.array([10.0, 10.0])
+        # abs_to_rel applies H forward
+        result = t.abs_to_rel(pt)
+        np.testing.assert_allclose(result, np.array([20.0, 30.0]))
+
+    def test_multiple_points_batch(self):
+        """Batch of points should all transform correctly."""
+        H = np.eye(3)
+        H[0, 2] = 15  # x-shift
+        t = HomographyTransformation(H)
+        pts = np.array([[0.0, 0.0], [100.0, 100.0]])
+        result = t.abs_to_rel(pts)
+        np.testing.assert_allclose(result, np.array([[15.0, 0.0], [115.0, 100.0]]))
+
+
+# ---------------------------------------------------------------
+# HomographyTransformationGetter
+# ---------------------------------------------------------------
+class TestHomographyTransformationGetter:
+    """Tests for HomographyTransformationGetter (requires OpenCV)."""
+
+    def test_insufficient_points_returns_none_first_call(self):
+        """With fewer than 4 points and no prior data, returns (True, None)."""
+        cv2 = pytest.importorskip("cv2")
+        from norfair.camera_motion import HomographyTransformationGetter
+
+        getter = HomographyTransformationGetter()
+        prev_pts = np.array([[1.0, 2.0], [3.0, 4.0]])  # only 2 points
+        curr_pts = np.array([[1.0, 2.0], [3.0, 4.0]])
+
+        update, transform = getter(curr_pts, prev_pts)
+        assert update is True
+        assert transform is None
+
+    def test_insufficient_points_returns_last_known(self):
+        """With fewer than 4 points but prior data, returns last known homography."""
+        cv2 = pytest.importorskip("cv2")
+        from norfair.camera_motion import HomographyTransformationGetter
+
+        getter = HomographyTransformationGetter()
+        # Seed internal data with an identity homography
+        getter.data = np.eye(3)
+
+        prev_pts = np.array([[1.0, 2.0]])  # only 1 point
+        curr_pts = np.array([[1.0, 2.0]])
+
+        update, transform = getter(curr_pts, prev_pts)
+        assert update is True
+        assert isinstance(transform, HomographyTransformation)
+        # The returned transformation should use the stored identity
+        pt = np.array([10.0, 20.0])
+        np.testing.assert_allclose(transform.abs_to_rel(pt), pt, atol=1e-10)
+
+    def test_identity_with_matching_points(self):
+        """Identical point sets should yield a near-identity homography."""
+        cv2 = pytest.importorskip("cv2")
+        from norfair.camera_motion import HomographyTransformationGetter
+
+        getter = HomographyTransformationGetter()
+        pts = np.array(
+            [[10.0, 10.0], [100.0, 10.0], [100.0, 100.0], [10.0, 100.0],
+             [50.0, 50.0], [75.0, 25.0]],
+            dtype=np.float32,
+        )
+        update, transform = getter(pts, pts)
+        assert isinstance(transform, HomographyTransformation)
+
+        # The resulting homography should be close to identity
+        test_pt = np.array([42.0, 73.0])
+        result = transform.abs_to_rel(test_pt)
+        np.testing.assert_allclose(result, test_pt, atol=1.0)
+
+    def test_known_translation_via_homography(self):
+        """A known shift in points should produce a translation-like homography."""
+        cv2 = pytest.importorskip("cv2")
+        from norfair.camera_motion import HomographyTransformationGetter
+
+        getter = HomographyTransformationGetter()
+        shift = np.array([5.0, -3.0])
+        prev_pts = np.array(
+            [[10.0, 10.0], [200.0, 10.0], [200.0, 200.0], [10.0, 200.0],
+             [100.0, 100.0], [50.0, 150.0]],
+            dtype=np.float32,
+        )
+        curr_pts = (prev_pts + shift).astype(np.float32)
+
+        update, transform = getter(curr_pts, prev_pts)
+        assert isinstance(transform, HomographyTransformation)
+
+        # Test that the transformation correctly maps a shifted point
+        test_pt = np.array([50.0, 50.0])
+        # abs_to_rel should apply the forward homography (prev -> curr)
+        result = transform.abs_to_rel(test_pt)
+        np.testing.assert_allclose(result, test_pt + shift, atol=1.0)
+
+
+# ---------------------------------------------------------------
+# MotionEstimator (requires OpenCV)
+# ---------------------------------------------------------------
+class TestMotionEstimator:
+    """Integration-level tests for MotionEstimator with synthetic frames."""
+
+    def test_first_frame_near_identity(self):
+        """The first call compares the frame against itself, yielding near-identity."""
+        cv2 = pytest.importorskip("cv2")
+        from norfair.camera_motion import MotionEstimator
+
+        estimator = MotionEstimator()
+        # Create a synthetic BGR frame with some texture
+        rng = np.random.RandomState(0)
+        frame = rng.randint(0, 256, (100, 100, 3), dtype=np.uint8)
+        result = estimator.update(frame)
+        # The first frame compares to itself (gray_prvs = gray_next), so we
+        # may get either None or a near-identity transformation.
+        if result is not None:
+            pt = np.array([25.0, 25.0])
+            transformed = result.abs_to_rel(pt)
+            np.testing.assert_allclose(transformed, pt, atol=2.0)
+
+    def test_identical_frames_produce_near_identity(self):
+        """Two identical frames should produce a near-identity transformation."""
+        cv2 = pytest.importorskip("cv2")
+        from norfair.camera_motion import MotionEstimator
+
+        # Use TranslationTransformationGetter for simpler results
+        getter = TranslationTransformationGetter()
+        estimator = MotionEstimator(transformations_getter=getter)
+
+        # Create a textured frame so goodFeaturesToTrack can find corners
+        rng = np.random.RandomState(42)
+        frame = rng.randint(0, 256, (200, 200, 3), dtype=np.uint8)
+
+        # First frame initializes state
+        estimator.update(frame)
+
+        # Second identical frame => no motion
+        transform = estimator.update(frame)
+        if transform is not None:
+            pt = np.array([50.0, 50.0])
+            result = transform.abs_to_rel(pt)
+            np.testing.assert_allclose(result, pt, atol=2.0)
+
+    def test_shifted_frame_detects_translation(self):
+        """A horizontally shifted frame should be detected as a translation."""
+        cv2 = pytest.importorskip("cv2")
+        from norfair.camera_motion import MotionEstimator
+
+        getter = TranslationTransformationGetter(bin_size=1.0)
+        estimator = MotionEstimator(
+            transformations_getter=getter,
+            max_points=300,
+            min_distance=10,
+            quality_level=0.01,
+        )
+
+        # Create a large textured frame with good features
+        rng = np.random.RandomState(123)
+        frame1 = rng.randint(0, 256, (300, 300, 3), dtype=np.uint8)
+        # Apply Gaussian blur to make optical flow more stable
+        frame1 = cv2.GaussianBlur(frame1, (5, 5), 0)
+
+        # Shift frame horizontally by 10 pixels using np.roll
+        shift_x = 10
+        frame2 = np.roll(frame1, shift_x, axis=1)
+
+        # First frame
+        estimator.update(frame1)
+        # Second frame with shift
+        transform = estimator.update(frame2)
+
+        # We should get a transformation back
+        assert transform is not None
+
+    def test_with_mask(self):
+        """MotionEstimator should accept an optional mask."""
+        cv2 = pytest.importorskip("cv2")
+        from norfair.camera_motion import MotionEstimator
+
+        getter = TranslationTransformationGetter()
+        estimator = MotionEstimator(transformations_getter=getter)
+
+        rng = np.random.RandomState(7)
+        frame = rng.randint(0, 256, (200, 200, 3), dtype=np.uint8)
+        mask = np.ones((200, 200), dtype=np.uint8) * 255
+
+        # Should not raise
+        estimator.update(frame, mask=mask)
+        result = estimator.update(frame, mask=mask)
+        # With identical frames and full mask, we should get a valid transform or None
+        # (either is fine; the key is no crash)
+
+    def test_draw_flow_flag(self):
+        """Setting draw_flow=True should not crash."""
+        cv2 = pytest.importorskip("cv2")
+        from norfair.camera_motion import MotionEstimator
+
+        estimator = MotionEstimator(draw_flow=True)
+
+        rng = np.random.RandomState(99)
+        frame1 = rng.randint(0, 256, (100, 100, 3), dtype=np.uint8)
+        frame2 = np.roll(frame1, 3, axis=1)
+
+        estimator.update(frame1.copy())
+        # Should not raise even with draw_flow enabled
+        estimator.update(frame2.copy())
+
+
+# ---------------------------------------------------------------
+# _get_sparse_flow and _calc_optical_flow helpers
+# ---------------------------------------------------------------
+class TestSparseFlowHelpers:
+    """Tests for the internal sparse-flow helper functions."""
+
+    def test_get_sparse_flow_with_identical_images(self):
+        """Sparse flow between identical images should yield near-zero displacement."""
+        cv2 = pytest.importorskip("cv2")
+        from norfair.camera_motion import _get_sparse_flow
+
+        rng = np.random.RandomState(0)
+        gray = rng.randint(0, 256, (200, 200), dtype=np.uint8)
+
+        curr_pts, prev_pts = _get_sparse_flow(gray, gray)
+        if len(curr_pts) > 0:
+            displacements = np.abs(curr_pts - prev_pts)
+            # Identical images => displacements should be near zero
+            assert displacements.mean() < 1.0
+
+    def test_get_sparse_flow_returns_matching_shapes(self):
+        """curr_pts and prev_pts should have the same shape."""
+        cv2 = pytest.importorskip("cv2")
+        from norfair.camera_motion import _get_sparse_flow
+
+        rng = np.random.RandomState(1)
+        gray1 = rng.randint(0, 256, (200, 200), dtype=np.uint8)
+        gray2 = np.roll(gray1, 5, axis=1)
+
+        curr_pts, prev_pts = _get_sparse_flow(gray2, gray1)
+        assert curr_pts.shape == prev_pts.shape
+        assert curr_pts.ndim == 2
+        if len(curr_pts) > 0:
+            assert curr_pts.shape[1] == 2
+
+    def test_calc_optical_flow_basic(self):
+        """_calc_optical_flow should return arrays or Nones."""
+        cv2 = pytest.importorskip("cv2")
+        from norfair.camera_motion import _calc_optical_flow
+
+        rng = np.random.RandomState(2)
+        gray = rng.randint(0, 256, (100, 100), dtype=np.uint8)
+
+        # Create some feature points in OpenCV's expected format (N, 1, 2)
+        prev_pts = np.array([[[10.0, 10.0]], [[50.0, 50.0]]], dtype=np.float32)
+        next_pts, status = _calc_optical_flow(gray, gray, prev_pts)
+
+        if next_pts is not None:
+            assert next_pts.shape[0] == prev_pts.shape[0]
+        if status is not None:
+            assert status.shape[0] == prev_pts.shape[0]

--- a/tests/test_drawing_integration.py
+++ b/tests/test_drawing_integration.py
@@ -14,16 +14,16 @@ import pytest
 
 cv2 = pytest.importorskip("cv2")
 
-from norfair import Detection
-from norfair.drawing import (
+from norfair import Detection  # noqa: E402
+from norfair.drawing import (  # noqa: E402
     AbsolutePaths,
     Paths,
     draw_absolute_grid,
     draw_boxes,
     draw_points,
 )
-from norfair.drawing.drawer import Drawable
-from norfair.drawing.fixed_camera import FixedCamera
+from norfair.drawing.drawer import Drawable  # noqa: E402
+from norfair.drawing.fixed_camera import FixedCamera  # noqa: E402
 
 # Visible color constant used in tests where the default palette color
 # would be black (e.g. Detection objects have id=None, so Palette returns
@@ -34,6 +34,7 @@ _GREEN = (0, 255, 0)
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _black_frame(size=200):
     """Return a size x size 3-channel black frame."""
@@ -92,6 +93,7 @@ class MockCoordTransform:
 # draw_boxes tests
 # ---------------------------------------------------------------------------
 
+
 class TestDrawBoxes:
     def test_basic_detection(self):
         """Detection drawn with an explicit visible color and thickness."""
@@ -117,8 +119,12 @@ class TestDrawBoxes:
         frame = _black_frame()
         det = Detection(points=np.array([[10, 10], [80, 80]]), label="cat")
         result = draw_boxes(
-            frame, [det], color=_GREEN, thickness=2,
-            draw_labels=True, draw_ids=True,
+            frame,
+            [det],
+            color=_GREEN,
+            thickness=2,
+            draw_labels=True,
+            draw_ids=True,
         )
         assert _frame_has_nonzero(result)
 
@@ -129,7 +135,11 @@ class TestDrawBoxes:
             scores=np.array([0.9, 0.8]),
         )
         result = draw_boxes(
-            frame, [det], color=_GREEN, thickness=2, draw_scores=True,
+            frame,
+            [det],
+            color=_GREEN,
+            thickness=2,
+            draw_scores=True,
         )
         assert _frame_has_nonzero(result)
 
@@ -137,8 +147,11 @@ class TestDrawBoxes:
         frame = _black_frame()
         det = Detection(points=np.array([[10, 10], [80, 80]]), label="dog")
         result = draw_boxes(
-            frame, [det], color=_GREEN,
-            draw_box=False, draw_labels=True,
+            frame,
+            [det],
+            color=_GREEN,
+            draw_box=False,
+            draw_labels=True,
         )
         # Even with draw_box=False, text may be drawn if label present.
         # Just ensure no crash.
@@ -168,6 +181,7 @@ class TestDrawBoxes:
 # ---------------------------------------------------------------------------
 # draw_points tests
 # ---------------------------------------------------------------------------
+
 
 class TestDrawPoints:
     def test_basic_detection(self):
@@ -201,8 +215,11 @@ class TestDrawPoints:
         det = Detection(points=np.array([[30, 30], [70, 70]]), label="test")
         # Should not crash even when circles are suppressed
         result = draw_points(
-            frame, [det], color=_GREEN,
-            draw_points=False, draw_labels=True,
+            frame,
+            [det],
+            color=_GREEN,
+            draw_points=False,
+            draw_labels=True,
         )
         assert result is not None
 
@@ -216,8 +233,11 @@ class TestDrawPoints:
         frame = _black_frame()
         det = Detection(points=np.array([[50, 50], [100, 100]]), label="cat")
         result = draw_points(
-            frame, [det], color=_GREEN,
-            text_color=(0, 0, 255), draw_labels=True,
+            frame,
+            [det],
+            color=_GREEN,
+            text_color=(0, 0, 255),
+            draw_labels=True,
         )
         assert _frame_has_nonzero(result)
 
@@ -225,6 +245,7 @@ class TestDrawPoints:
 # ---------------------------------------------------------------------------
 # NaN / Inf coordinate safety
 # ---------------------------------------------------------------------------
+
 
 class TestNanInfSafety:
     """Non-finite coordinates must not crash; the frame should stay unchanged."""
@@ -285,6 +306,7 @@ class TestNanInfSafety:
 # Empty / None drawables
 # ---------------------------------------------------------------------------
 
+
 class TestEmptyNoneDrawables:
     def test_draw_boxes_empty_list(self):
         frame = _black_frame()
@@ -328,6 +350,7 @@ class TestEmptyNoneDrawables:
 # Paths
 # ---------------------------------------------------------------------------
 
+
 class TestPaths:
     def test_draw_produces_output(self):
         frame = _black_frame()
@@ -342,9 +365,7 @@ class TestPaths:
         path_drawer = Paths(attenuation=0.0)  # no fading
         for _ in range(5):
             frame = _black_frame()
-            obj = MockTrackedObject(
-                estimate=np.array([[50, 50], [80, 80]]), obj_id=1
-            )
+            obj = MockTrackedObject(estimate=np.array([[50, 50], [80, 80]]), obj_id=1)
             result = path_drawer.draw(frame, [obj])
         assert _frame_has_nonzero(result)
 
@@ -385,6 +406,7 @@ class TestPaths:
 # AbsolutePaths
 # ---------------------------------------------------------------------------
 
+
 class TestAbsolutePaths:
     def test_draw_without_transform(self):
         frame = _black_frame()
@@ -407,9 +429,7 @@ class TestAbsolutePaths:
         for i in range(5):
             frame = _black_frame()
             obj = MockTrackedObject(
-                estimate=np.array(
-                    [[30 + i * 5, 30 + i * 5], [60 + i * 5, 60 + i * 5]]
-                ),
+                estimate=np.array([[30 + i * 5, 30 + i * 5], [60 + i * 5, 60 + i * 5]]),
                 obj_id=1,
             )
             result = abs_paths.draw(frame, [obj], coord_transform=transform)
@@ -465,12 +485,16 @@ class TestAbsolutePaths:
 # draw_absolute_grid
 # ---------------------------------------------------------------------------
 
+
 class TestDrawAbsoluteGrid:
     def test_no_transform(self):
         """Grid with a visible color and no coord transform."""
         frame = _black_frame()
         draw_absolute_grid(
-            frame, coord_transformations=None, grid_size=10, color=_GREEN,
+            frame,
+            coord_transformations=None,
+            grid_size=10,
+            color=_GREEN,
         )
         assert _frame_has_nonzero(frame)
 
@@ -478,7 +502,10 @@ class TestDrawAbsoluteGrid:
         frame = _black_frame()
         transform = MockCoordTransform()
         draw_absolute_grid(
-            frame, coord_transformations=transform, grid_size=10, color=_GREEN,
+            frame,
+            coord_transformations=transform,
+            grid_size=10,
+            color=_GREEN,
         )
         assert _frame_has_nonzero(frame)
 
@@ -495,8 +522,11 @@ class TestDrawAbsoluteGrid:
     def test_polar_mode(self):
         frame = _black_frame()
         draw_absolute_grid(
-            frame, coord_transformations=None, grid_size=10,
-            polar=True, color=_GREEN,
+            frame,
+            coord_transformations=None,
+            grid_size=10,
+            polar=True,
+            color=_GREEN,
         )
         assert _frame_has_nonzero(frame)
 
@@ -515,7 +545,10 @@ class TestDrawAbsoluteGrid:
     def test_large_grid_size(self):
         frame = _black_frame()
         draw_absolute_grid(
-            frame, coord_transformations=None, grid_size=50, color=_GREEN,
+            frame,
+            coord_transformations=None,
+            grid_size=50,
+            color=_GREEN,
         )
         assert _frame_has_nonzero(frame)
 
@@ -523,6 +556,7 @@ class TestDrawAbsoluteGrid:
 # ---------------------------------------------------------------------------
 # FixedCamera
 # ---------------------------------------------------------------------------
+
 
 class TestFixedCamera:
     def test_basic_adjust_frame(self):
@@ -602,6 +636,7 @@ class TestFixedCamera:
 # Drawable wrapper
 # ---------------------------------------------------------------------------
 
+
 class TestDrawable:
     def test_from_detection(self):
         det = Detection(points=np.array([[10, 20], [30, 40]]), label="car")
@@ -648,6 +683,7 @@ class TestDrawable:
 # draw_boxes / draw_points with Drawable wrapper
 # ---------------------------------------------------------------------------
 
+
 class TestDrawableWithDrawFunctions:
     def test_draw_boxes_accepts_drawable(self):
         frame = _black_frame()
@@ -673,6 +709,7 @@ class TestDrawableWithDrawFunctions:
 # ---------------------------------------------------------------------------
 # Color strategy variants for draw_boxes
 # ---------------------------------------------------------------------------
+
 
 class TestColorStrategies:
     def test_by_id_with_real_id(self):

--- a/tests/test_drawing_integration.py
+++ b/tests/test_drawing_integration.py
@@ -1,0 +1,713 @@
+"""Integration tests for norfair.drawing functions.
+
+These tests exercise the public drawing API with real numpy arrays and
+(when available) OpenCV, verifying that:
+  - drawing functions produce visible output on a black canvas,
+  - edge cases (NaN/Inf coordinates, empty/None drawables) are handled
+    gracefully without crashes,
+  - Paths, AbsolutePaths, FixedCamera, and draw_absolute_grid work
+    with mock tracked objects and coordinate transforms.
+"""
+
+import numpy as np
+import pytest
+
+cv2 = pytest.importorskip("cv2")
+
+from norfair import Detection
+from norfair.drawing import (
+    AbsolutePaths,
+    Paths,
+    draw_absolute_grid,
+    draw_boxes,
+    draw_points,
+)
+from norfair.drawing.drawer import Drawable
+from norfair.drawing.fixed_camera import FixedCamera
+
+# Visible color constant used in tests where the default palette color
+# would be black (e.g. Detection objects have id=None, so Palette returns
+# Color.black which is invisible on a black frame).
+_GREEN = (0, 255, 0)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _black_frame(size=200):
+    """Return a size x size 3-channel black frame."""
+    return np.zeros((size, size, 3), dtype=np.uint8)
+
+
+def _frame_has_nonzero(frame):
+    """Return True if the frame contains any non-zero pixels."""
+    return frame.any()
+
+
+class MockTrackedObject:
+    """Minimal stand-in for TrackedObject, satisfying the drawing API.
+
+    The drawing code accesses: .estimate, .id, .label, .scores,
+    .live_points, .abs_to_rel, and .get_estimate().
+    """
+
+    def __init__(
+        self,
+        estimate=None,
+        obj_id=1,
+        label=None,
+        live_points=None,
+        scores=None,
+        abs_to_rel=None,
+    ):
+        if estimate is None:
+            estimate = np.array([[30, 30], [70, 70]])
+        self.estimate = np.asarray(estimate, dtype=float)
+        self.id = obj_id
+        self.label = label
+        self.scores = scores
+        self.live_points = (
+            live_points
+            if live_points is not None
+            else np.ones(len(self.estimate), dtype=bool)
+        )
+        self.abs_to_rel = abs_to_rel
+
+    def get_estimate(self, absolute=False):
+        return self.estimate
+
+
+class MockCoordTransform:
+    """Minimal coordinate transformation (identity)."""
+
+    def abs_to_rel(self, points):
+        return points
+
+    def rel_to_abs(self, points):
+        return points
+
+
+# ---------------------------------------------------------------------------
+# draw_boxes tests
+# ---------------------------------------------------------------------------
+
+class TestDrawBoxes:
+    def test_basic_detection(self):
+        """Detection drawn with an explicit visible color and thickness."""
+        frame = _black_frame()
+        det = Detection(points=np.array([[10, 10], [50, 50]]))
+        result = draw_boxes(frame, [det], color=_GREEN, thickness=2)
+        assert _frame_has_nonzero(result)
+
+    def test_multiple_detections(self):
+        frame = _black_frame()
+        det1 = Detection(points=np.array([[10, 10], [50, 50]]))
+        det2 = Detection(points=np.array([[60, 60], [90, 90]]))
+        result = draw_boxes(frame, [det1, det2], color=_GREEN, thickness=2)
+        assert _frame_has_nonzero(result)
+
+    def test_with_color_tuple(self):
+        frame = _black_frame()
+        det = Detection(points=np.array([[10, 10], [50, 50]]))
+        result = draw_boxes(frame, [det], color=(0, 255, 0), thickness=2)
+        assert _frame_has_nonzero(result)
+
+    def test_with_labels_and_ids(self):
+        frame = _black_frame()
+        det = Detection(points=np.array([[10, 10], [80, 80]]), label="cat")
+        result = draw_boxes(
+            frame, [det], color=_GREEN, thickness=2,
+            draw_labels=True, draw_ids=True,
+        )
+        assert _frame_has_nonzero(result)
+
+    def test_with_scores(self):
+        frame = _black_frame()
+        det = Detection(
+            points=np.array([[10, 10], [80, 80]]),
+            scores=np.array([0.9, 0.8]),
+        )
+        result = draw_boxes(
+            frame, [det], color=_GREEN, thickness=2, draw_scores=True,
+        )
+        assert _frame_has_nonzero(result)
+
+    def test_draw_box_false_still_draws_text(self):
+        frame = _black_frame()
+        det = Detection(points=np.array([[10, 10], [80, 80]]), label="dog")
+        result = draw_boxes(
+            frame, [det], color=_GREEN,
+            draw_box=False, draw_labels=True,
+        )
+        # Even with draw_box=False, text may be drawn if label present.
+        # Just ensure no crash.
+        assert result is not None
+
+    def test_with_explicit_thickness(self):
+        frame = _black_frame()
+        det = Detection(points=np.array([[10, 10], [50, 50]]))
+        result = draw_boxes(frame, [det], color=_GREEN, thickness=3)
+        assert _frame_has_nonzero(result)
+
+    def test_returns_same_array(self):
+        """draw_boxes modifies the frame in place and returns it."""
+        frame = _black_frame()
+        det = Detection(points=np.array([[10, 10], [50, 50]]))
+        result = draw_boxes(frame, [det], color=_GREEN, thickness=2)
+        assert result is frame
+
+    def test_auto_thickness_on_large_frame(self):
+        """On a large frame the auto-computed thickness is non-zero."""
+        frame = _black_frame(size=800)
+        det = Detection(points=np.array([[100, 100], [400, 400]]))
+        result = draw_boxes(frame, [det], color=_GREEN)
+        assert _frame_has_nonzero(result)
+
+
+# ---------------------------------------------------------------------------
+# draw_points tests
+# ---------------------------------------------------------------------------
+
+class TestDrawPoints:
+    def test_basic_detection(self):
+        frame = _black_frame()
+        det = Detection(points=np.array([[10, 10], [50, 50]]))
+        result = draw_points(frame, [det], color=_GREEN)
+        assert _frame_has_nonzero(result)
+
+    def test_multiple_detections(self):
+        frame = _black_frame()
+        det1 = Detection(points=np.array([[20, 20], [40, 40]]))
+        det2 = Detection(points=np.array([[60, 60], [80, 80]]))
+        result = draw_points(frame, [det1, det2], color=_GREEN)
+        assert _frame_has_nonzero(result)
+
+    def test_with_color_tuple(self):
+        frame = _black_frame()
+        det = Detection(points=np.array([[30, 30], [70, 70]]))
+        result = draw_points(frame, [det], color=(255, 0, 0))
+        assert _frame_has_nonzero(result)
+
+    def test_with_custom_radius(self):
+        frame = _black_frame()
+        det = Detection(points=np.array([[50, 50], [100, 100]]))
+        result = draw_points(frame, [det], color=_GREEN, radius=5)
+        assert _frame_has_nonzero(result)
+
+    def test_draw_points_false(self):
+        """When draw_points=False only text is drawn, circles are omitted."""
+        frame = _black_frame()
+        det = Detection(points=np.array([[30, 30], [70, 70]]), label="test")
+        # Should not crash even when circles are suppressed
+        result = draw_points(
+            frame, [det], color=_GREEN,
+            draw_points=False, draw_labels=True,
+        )
+        assert result is not None
+
+    def test_single_point_detection(self):
+        frame = _black_frame()
+        det = Detection(points=np.array([[100, 100]]))
+        result = draw_points(frame, [det], color=_GREEN)
+        assert _frame_has_nonzero(result)
+
+    def test_with_text_color(self):
+        frame = _black_frame()
+        det = Detection(points=np.array([[50, 50], [100, 100]]), label="cat")
+        result = draw_points(
+            frame, [det], color=_GREEN,
+            text_color=(0, 0, 255), draw_labels=True,
+        )
+        assert _frame_has_nonzero(result)
+
+
+# ---------------------------------------------------------------------------
+# NaN / Inf coordinate safety
+# ---------------------------------------------------------------------------
+
+class TestNanInfSafety:
+    """Non-finite coordinates must not crash; the frame should stay unchanged."""
+
+    def test_draw_boxes_nan(self):
+        frame = _black_frame()
+        original = frame.copy()
+        det = Detection(points=np.array([[np.nan, np.nan], [50, 50]]))
+        result = draw_boxes(frame, [det], color=_GREEN, thickness=2)
+        np.testing.assert_array_equal(result, original)
+
+    def test_draw_boxes_inf(self):
+        frame = _black_frame()
+        original = frame.copy()
+        det = Detection(points=np.array([[np.inf, 10], [50, 50]]))
+        result = draw_boxes(frame, [det], color=_GREEN, thickness=2)
+        np.testing.assert_array_equal(result, original)
+
+    def test_draw_boxes_negative_inf(self):
+        frame = _black_frame()
+        original = frame.copy()
+        det = Detection(points=np.array([[-np.inf, 10], [50, 50]]))
+        result = draw_boxes(frame, [det], color=_GREEN, thickness=2)
+        np.testing.assert_array_equal(result, original)
+
+    def test_draw_points_nan(self):
+        frame = _black_frame()
+        original = frame.copy()
+        det = Detection(points=np.array([[np.nan, np.nan], [np.nan, np.nan]]))
+        result = draw_points(frame, [det], color=_GREEN)
+        np.testing.assert_array_equal(result, original)
+
+    def test_draw_points_inf(self):
+        frame = _black_frame()
+        original = frame.copy()
+        det = Detection(points=np.array([[np.inf, np.inf], [np.inf, np.inf]]))
+        result = draw_points(frame, [det], color=_GREEN)
+        np.testing.assert_array_equal(result, original)
+
+    def test_draw_points_mixed_nan_valid(self):
+        """One valid point, one NaN -- valid point should still draw."""
+        frame = _black_frame()
+        det = Detection(points=np.array([[50, 50], [np.nan, np.nan]]))
+        result = draw_points(frame, [det], color=_GREEN)
+        # The valid point should produce pixels
+        assert _frame_has_nonzero(result)
+
+    def test_draw_boxes_all_nan_detection(self):
+        """A fully NaN detection should leave the frame untouched."""
+        frame = _black_frame()
+        original = frame.copy()
+        det = Detection(points=np.array([[np.nan, np.nan], [np.nan, np.nan]]))
+        result = draw_boxes(frame, [det], color=_GREEN, thickness=2)
+        np.testing.assert_array_equal(result, original)
+
+
+# ---------------------------------------------------------------------------
+# Empty / None drawables
+# ---------------------------------------------------------------------------
+
+class TestEmptyNoneDrawables:
+    def test_draw_boxes_empty_list(self):
+        frame = _black_frame()
+        original = frame.copy()
+        result = draw_boxes(frame, [])
+        np.testing.assert_array_equal(result, original)
+
+    def test_draw_boxes_none(self):
+        frame = _black_frame()
+        original = frame.copy()
+        result = draw_boxes(frame, None)
+        np.testing.assert_array_equal(result, original)
+
+    def test_draw_points_empty_list(self):
+        frame = _black_frame()
+        original = frame.copy()
+        result = draw_points(frame, [])
+        np.testing.assert_array_equal(result, original)
+
+    def test_draw_points_none(self):
+        frame = _black_frame()
+        original = frame.copy()
+        result = draw_points(frame, None)
+        np.testing.assert_array_equal(result, original)
+
+    def test_draw_boxes_default_drawables(self):
+        """Calling with no drawables argument at all uses the default None."""
+        frame = _black_frame()
+        original = frame.copy()
+        result = draw_boxes(frame)
+        np.testing.assert_array_equal(result, original)
+
+    def test_draw_points_default_drawables(self):
+        frame = _black_frame()
+        original = frame.copy()
+        result = draw_points(frame)
+        np.testing.assert_array_equal(result, original)
+
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+class TestPaths:
+    def test_draw_produces_output(self):
+        frame = _black_frame()
+        obj = MockTrackedObject(estimate=np.array([[50, 50], [80, 80]]), obj_id=1)
+        path_drawer = Paths()
+        result = path_drawer.draw(frame, [obj])
+        # Palette picks a non-black color for id=1, so pixels should appear
+        assert _frame_has_nonzero(result)
+
+    def test_draw_multiple_frames(self):
+        """Drawing across multiple frames accumulates a path."""
+        path_drawer = Paths(attenuation=0.0)  # no fading
+        for _ in range(5):
+            frame = _black_frame()
+            obj = MockTrackedObject(
+                estimate=np.array([[50, 50], [80, 80]]), obj_id=1
+            )
+            result = path_drawer.draw(frame, [obj])
+        assert _frame_has_nonzero(result)
+
+    def test_draw_with_custom_color(self):
+        frame = _black_frame()
+        obj = MockTrackedObject(estimate=np.array([[40, 40], [60, 60]]), obj_id=2)
+        path_drawer = Paths(color=(0, 0, 255), radius=3, thickness=2)
+        result = path_drawer.draw(frame, [obj])
+        assert _frame_has_nonzero(result)
+
+    def test_draw_empty_objects(self):
+        frame = _black_frame()
+        path_drawer = Paths()
+        result = path_drawer.draw(frame, [])
+        # With no objects, result should still be valid (blended black frames)
+        assert result is not None
+
+    def test_draw_with_nan_estimate(self):
+        """NaN estimates should not crash the path drawer."""
+        frame = _black_frame()
+        obj = MockTrackedObject(
+            estimate=np.array([[np.nan, np.nan], [np.nan, np.nan]]), obj_id=3
+        )
+        path_drawer = Paths()
+        result = path_drawer.draw(frame, [obj])
+        assert result is not None
+
+    def test_draw_with_attenuation(self):
+        """Non-zero attenuation should still produce visible output."""
+        path_drawer = Paths(attenuation=0.5)
+        frame = _black_frame()
+        obj = MockTrackedObject(estimate=np.array([[50, 50], [80, 80]]), obj_id=1)
+        result = path_drawer.draw(frame, [obj])
+        assert _frame_has_nonzero(result)
+
+
+# ---------------------------------------------------------------------------
+# AbsolutePaths
+# ---------------------------------------------------------------------------
+
+class TestAbsolutePaths:
+    def test_draw_without_transform(self):
+        frame = _black_frame()
+        obj = MockTrackedObject(estimate=np.array([[50, 50], [80, 80]]), obj_id=1)
+        abs_paths = AbsolutePaths()
+        result = abs_paths.draw(frame, [obj])
+        assert _frame_has_nonzero(result)
+
+    def test_draw_with_transform(self):
+        frame = _black_frame()
+        obj = MockTrackedObject(estimate=np.array([[50, 50], [80, 80]]), obj_id=1)
+        transform = MockCoordTransform()
+        abs_paths = AbsolutePaths()
+        result = abs_paths.draw(frame, [obj], coord_transform=transform)
+        assert _frame_has_nonzero(result)
+
+    def test_draw_multiple_frames_accumulates(self):
+        abs_paths = AbsolutePaths(max_history=5)
+        transform = MockCoordTransform()
+        for i in range(5):
+            frame = _black_frame()
+            obj = MockTrackedObject(
+                estimate=np.array(
+                    [[30 + i * 5, 30 + i * 5], [60 + i * 5, 60 + i * 5]]
+                ),
+                obj_id=1,
+            )
+            result = abs_paths.draw(frame, [obj], coord_transform=transform)
+        assert _frame_has_nonzero(result)
+
+    def test_draw_with_custom_settings(self):
+        frame = _black_frame()
+        obj = MockTrackedObject(estimate=np.array([[40, 40], [90, 90]]), obj_id=2)
+        abs_paths = AbsolutePaths(color=(255, 0, 0), radius=4, thickness=2)
+        result = abs_paths.draw(frame, [obj])
+        assert _frame_has_nonzero(result)
+
+    def test_draw_empty_objects(self):
+        frame = _black_frame()
+        abs_paths = AbsolutePaths()
+        result = abs_paths.draw(frame, [])
+        assert result is not None
+
+    def test_dead_points_object_skipped(self):
+        """Objects with all dead live_points should be skipped."""
+        frame = _black_frame()
+        original = frame.copy()
+        obj = MockTrackedObject(
+            estimate=np.array([[50, 50], [80, 80]]),
+            obj_id=1,
+            live_points=np.array([False, False]),
+        )
+        abs_paths = AbsolutePaths()
+        result = abs_paths.draw(frame, [obj])
+        # No live points => nothing drawn, frame should be unchanged
+        np.testing.assert_array_equal(result, original)
+
+    def test_cleanup_dead_object_ids(self):
+        """Past points for objects no longer tracked should be cleaned up."""
+        abs_paths = AbsolutePaths()
+        obj1 = MockTrackedObject(estimate=np.array([[50, 50], [80, 80]]), obj_id=1)
+        obj2 = MockTrackedObject(estimate=np.array([[20, 20], [40, 40]]), obj_id=2)
+
+        # Frame 1: both objects
+        frame = _black_frame()
+        abs_paths.draw(frame, [obj1, obj2])
+        assert 1 in abs_paths.past_points
+        assert 2 in abs_paths.past_points
+
+        # Frame 2: only obj1 present
+        frame = _black_frame()
+        abs_paths.draw(frame, [obj1])
+        assert 1 in abs_paths.past_points
+        assert 2 not in abs_paths.past_points
+
+
+# ---------------------------------------------------------------------------
+# draw_absolute_grid
+# ---------------------------------------------------------------------------
+
+class TestDrawAbsoluteGrid:
+    def test_no_transform(self):
+        """Grid with a visible color and no coord transform."""
+        frame = _black_frame()
+        draw_absolute_grid(
+            frame, coord_transformations=None, grid_size=10, color=_GREEN,
+        )
+        assert _frame_has_nonzero(frame)
+
+    def test_with_identity_transform(self):
+        frame = _black_frame()
+        transform = MockCoordTransform()
+        draw_absolute_grid(
+            frame, coord_transformations=transform, grid_size=10, color=_GREEN,
+        )
+        assert _frame_has_nonzero(frame)
+
+    def test_custom_color(self):
+        frame = _black_frame()
+        draw_absolute_grid(
+            frame,
+            coord_transformations=None,
+            grid_size=10,
+            color=(0, 255, 0),
+        )
+        assert _frame_has_nonzero(frame)
+
+    def test_polar_mode(self):
+        frame = _black_frame()
+        draw_absolute_grid(
+            frame, coord_transformations=None, grid_size=10,
+            polar=True, color=_GREEN,
+        )
+        assert _frame_has_nonzero(frame)
+
+    def test_custom_radius_and_thickness(self):
+        frame = _black_frame()
+        draw_absolute_grid(
+            frame,
+            coord_transformations=None,
+            grid_size=10,
+            radius=5,
+            thickness=2,
+            color=_GREEN,
+        )
+        assert _frame_has_nonzero(frame)
+
+    def test_large_grid_size(self):
+        frame = _black_frame()
+        draw_absolute_grid(
+            frame, coord_transformations=None, grid_size=50, color=_GREEN,
+        )
+        assert _frame_has_nonzero(frame)
+
+
+# ---------------------------------------------------------------------------
+# FixedCamera
+# ---------------------------------------------------------------------------
+
+class TestFixedCamera:
+    def test_basic_adjust_frame(self):
+        """FixedCamera should produce a larger canvas with the frame embedded."""
+        from norfair.camera_motion import TranslationTransformation
+
+        frame = _black_frame()
+        # Draw something on the frame so we can verify it ends up in the output
+        cv2.rectangle(frame, (10, 10), (50, 50), (255, 255, 255), 2)
+
+        transform = TranslationTransformation(movement_vector=np.array([0, 0]))
+        camera = FixedCamera(scale=2)
+        result = camera.adjust_frame(frame, transform)
+
+        # Output should be larger than input
+        assert result.shape[0] == 400
+        assert result.shape[1] == 400
+        # The white rectangle should be present somewhere in the output
+        assert _frame_has_nonzero(result)
+
+    def test_with_translation(self):
+        from norfair.camera_motion import TranslationTransformation
+
+        frame = _black_frame()
+        cv2.rectangle(frame, (10, 10), (50, 50), (0, 0, 255), -1)
+
+        transform = TranslationTransformation(movement_vector=np.array([5, 5]))
+        camera = FixedCamera(scale=3)
+        result = camera.adjust_frame(frame, transform)
+
+        assert result.shape[0] == 600
+        assert result.shape[1] == 600
+        assert _frame_has_nonzero(result)
+
+    def test_multiple_frames(self):
+        from norfair.camera_motion import TranslationTransformation
+
+        camera = FixedCamera(scale=2, attenuation=0.05)
+        for i in range(5):
+            frame = _black_frame()
+            cv2.circle(frame, (100, 100), 10, (0, 255, 0), -1)
+            transform = TranslationTransformation(
+                movement_vector=np.array([i * 2, i * 2])
+            )
+            result = camera.adjust_frame(frame, transform)
+
+        assert _frame_has_nonzero(result)
+
+    def test_custom_scale(self):
+        from norfair.camera_motion import TranslationTransformation
+
+        frame = _black_frame()
+        cv2.circle(frame, (50, 50), 5, (128, 128, 128), -1)
+
+        transform = TranslationTransformation(movement_vector=np.array([0, 0]))
+        camera = FixedCamera(scale=1.5)
+        result = camera.adjust_frame(frame, transform)
+
+        assert result.shape[0] == 300
+        assert result.shape[1] == 300
+        assert _frame_has_nonzero(result)
+
+    def test_zero_translation(self):
+        """A zero-vector translation should center the frame in the canvas."""
+        from norfair.camera_motion import TranslationTransformation
+
+        frame = _black_frame()
+        cv2.circle(frame, (100, 100), 20, (255, 128, 0), -1)
+
+        transform = TranslationTransformation(movement_vector=np.array([0, 0]))
+        camera = FixedCamera(scale=2)
+        result = camera.adjust_frame(frame, transform)
+        assert _frame_has_nonzero(result)
+
+
+# ---------------------------------------------------------------------------
+# Drawable wrapper
+# ---------------------------------------------------------------------------
+
+class TestDrawable:
+    def test_from_detection(self):
+        det = Detection(points=np.array([[10, 20], [30, 40]]), label="car")
+        d = Drawable(det)
+        assert d.label == "car"
+        assert d.id is None
+        np.testing.assert_array_equal(d.points, det.points)
+        assert d.live_points.all()
+
+    def test_from_detection_with_scores(self):
+        det = Detection(
+            points=np.array([[10, 20], [30, 40]]),
+            scores=np.array([0.9, 0.8]),
+        )
+        d = Drawable(det)
+        np.testing.assert_array_equal(d.scores, np.array([0.9, 0.8]))
+
+    def test_from_explicit_fields(self):
+        pts = np.array([[5, 5], [15, 15]])
+        lp = np.array([True, False])
+        d = Drawable(
+            points=pts,
+            id=42,
+            label="person",
+            live_points=lp,
+        )
+        assert d.id == 42
+        assert d.label == "person"
+        np.testing.assert_array_equal(d.points, pts)
+        np.testing.assert_array_equal(d.live_points, lp)
+
+    def test_invalid_obj_type_raises(self):
+        with pytest.raises(ValueError, match="Expecting a Detection"):
+            Drawable("not a detection")
+
+    def test_from_none_with_explicit_fields(self):
+        pts = np.array([[1, 2]])
+        d = Drawable(obj=None, points=pts, id=99)
+        assert d.id == 99
+        np.testing.assert_array_equal(d.points, pts)
+
+
+# ---------------------------------------------------------------------------
+# draw_boxes / draw_points with Drawable wrapper
+# ---------------------------------------------------------------------------
+
+class TestDrawableWithDrawFunctions:
+    def test_draw_boxes_accepts_drawable(self):
+        frame = _black_frame()
+        d = Drawable(
+            points=np.array([[10, 10], [60, 60]]),
+            id=1,
+            live_points=np.array([True, True]),
+        )
+        result = draw_boxes(frame, [d], color=_GREEN, thickness=2)
+        assert _frame_has_nonzero(result)
+
+    def test_draw_points_accepts_drawable(self):
+        frame = _black_frame()
+        d = Drawable(
+            points=np.array([[30, 30], [70, 70]]),
+            id=2,
+            live_points=np.array([True, True]),
+        )
+        result = draw_points(frame, [d], color=_GREEN)
+        assert _frame_has_nonzero(result)
+
+
+# ---------------------------------------------------------------------------
+# Color strategy variants for draw_boxes
+# ---------------------------------------------------------------------------
+
+class TestColorStrategies:
+    def test_by_id_with_real_id(self):
+        """Drawable with a real integer id gets a non-black palette color."""
+        frame = _black_frame()
+        d = Drawable(
+            points=np.array([[10, 10], [50, 50]]),
+            id=7,
+            live_points=np.array([True, True]),
+        )
+        result = draw_boxes(frame, [d], color="by_id", thickness=2)
+        assert _frame_has_nonzero(result)
+
+    def test_by_label(self):
+        frame = _black_frame()
+        det = Detection(points=np.array([[10, 10], [50, 50]]), label="truck")
+        result = draw_boxes(frame, [det], color="by_label", thickness=2)
+        assert _frame_has_nonzero(result)
+
+    def test_random(self):
+        frame = _black_frame()
+        det = Detection(points=np.array([[10, 10], [50, 50]]))
+        # "random" uses np.random.rand() as the hash key; very unlikely
+        # to be black.
+        result = draw_boxes(frame, [det], color="random", thickness=2)
+        assert _frame_has_nonzero(result)
+
+    def test_hex_color(self):
+        frame = _black_frame()
+        det = Detection(points=np.array([[10, 10], [50, 50]]))
+        result = draw_boxes(frame, [det], color="#FF0000", thickness=2)
+        assert _frame_has_nonzero(result)
+
+    def test_explicit_bgr_tuple(self):
+        frame = _black_frame()
+        det = Detection(points=np.array([[10, 10], [50, 50]]))
+        result = draw_boxes(frame, [det], color=(255, 128, 0), thickness=2)
+        assert _frame_has_nonzero(result)

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -42,64 +42,66 @@ def test_params():
 @pytest.mark.parametrize(
     "filter_factory", [FilterPyKalmanFilterFactory(), OptimizedKalmanFilterFactory()]
 )
-def test_simple(filter_factory):
-    for delay in [0, 1, 3]:
-        for counter_max in [delay + 1, delay + 3]:
-            #
-            # tests a simple static detection
-            #
-            tracker = Tracker(
-                "euclidean",
-                initialization_delay=delay,
-                distance_threshold=100,
-                hit_counter_max=counter_max,
-                filter_factory=filter_factory,
-            )
+@pytest.mark.parametrize(
+    "delay, counter_max",
+    [(0, 1), (0, 3), (1, 2), (1, 4), (3, 4), (3, 6)],
+)
+def test_simple(filter_factory, delay, counter_max):
+    #
+    # tests a simple static detection
+    #
+    tracker = Tracker(
+        "euclidean",
+        initialization_delay=delay,
+        distance_threshold=100,
+        hit_counter_max=counter_max,
+        filter_factory=filter_factory,
+    )
 
-            detections = [Detection(points=np.array([[1, 1]]))]
+    detections = [Detection(points=np.array([[1, 1]]))]
 
-            # test the delay
-            for _age in range(delay):
-                assert len(tracker.update(detections)) == 0
+    # test the delay
+    for _age in range(delay):
+        assert len(tracker.update(detections)) == 0
 
-            # build up hit_counter from delay+1 to counter_max
-            for age in range(delay, counter_max):
-                tracked_objects = tracker.update(detections)
-                assert len(tracked_objects) == 1
-                obj = tracked_objects[0]
-                np.testing.assert_almost_equal(
-                    tracked_objects[0].estimate, np.array([[1, 1]])
-                )
-                assert obj.age == age
-                assert obj.hit_counter == age + 1
+    # build up hit_counter from delay+1 to counter_max
+    for age in range(delay, counter_max):
+        tracked_objects = tracker.update(detections)
+        assert len(tracked_objects) == 1
+        obj = tracked_objects[0]
+        np.testing.assert_almost_equal(
+            tracked_objects[0].estimate, np.array([[1, 1]])
+        )
+        assert obj.age == age
+        assert obj.hit_counter == age + 1
 
-            # check that counter is capped at counter_max
-            for age in range(counter_max, counter_max + 3):
-                tracked_objects = tracker.update(detections)
-                assert len(tracked_objects) == 1
-                obj = tracked_objects[0]
-                np.testing.assert_almost_equal(
-                    tracked_objects[0].estimate, np.array([[1, 1]])
-                )
-                assert obj.age == age
-                assert obj.hit_counter == counter_max
+    # check that counter is capped at counter_max
+    for age in range(counter_max, counter_max + 3):
+        tracked_objects = tracker.update(detections)
+        assert len(tracked_objects) == 1
+        obj = tracked_objects[0]
+        np.testing.assert_almost_equal(
+            tracked_objects[0].estimate, np.array([[1, 1]])
+        )
+        assert obj.age == age
+        assert obj.hit_counter == counter_max
 
-            # check that counter goes down to 0 wen no detections
-            # Set age explicitly after previous loop (was counter_max + 2)
-            age = counter_max + 2
-            for counter in range(counter_max - 1, -1, -1):
-                age += 1
-                tracked_objects = tracker.update()
-                assert len(tracked_objects) == 1
-                obj = tracked_objects[0]
-                np.testing.assert_almost_equal(
-                    tracked_objects[0].estimate, np.array([[1, 1]])
-                )
-                assert obj.age == age
-                assert obj.hit_counter == counter
+    # check that counter goes down to 0 wen no detections
+    # Set age explicitly after previous loop (was counter_max + 2)
+    age = counter_max + 2
+    for counter in range(counter_max - 1, -1, -1):
+        age += 1
+        tracked_objects = tracker.update()
+        assert len(tracked_objects) == 1
+        obj = tracked_objects[0]
+        np.testing.assert_almost_equal(
+            tracked_objects[0].estimate, np.array([[1, 1]])
+        )
+        assert obj.age == age
+        assert obj.hit_counter == counter
 
-            # check that object dissapears in the next frame
-            assert len(tracker.update()) == 0
+    # check that object dissapears in the next frame
+    assert len(tracker.update()) == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -69,9 +69,7 @@ def test_simple(filter_factory, delay, counter_max):
         tracked_objects = tracker.update(detections)
         assert len(tracked_objects) == 1
         obj = tracked_objects[0]
-        np.testing.assert_almost_equal(
-            tracked_objects[0].estimate, np.array([[1, 1]])
-        )
+        np.testing.assert_almost_equal(tracked_objects[0].estimate, np.array([[1, 1]]))
         assert obj.age == age
         assert obj.hit_counter == age + 1
 
@@ -80,13 +78,11 @@ def test_simple(filter_factory, delay, counter_max):
         tracked_objects = tracker.update(detections)
         assert len(tracked_objects) == 1
         obj = tracked_objects[0]
-        np.testing.assert_almost_equal(
-            tracked_objects[0].estimate, np.array([[1, 1]])
-        )
+        np.testing.assert_almost_equal(tracked_objects[0].estimate, np.array([[1, 1]]))
         assert obj.age == age
         assert obj.hit_counter == counter_max
 
-    # check that counter goes down to 0 wen no detections
+    # check that counter goes down to 0 when no detections
     # Set age explicitly after previous loop (was counter_max + 2)
     age = counter_max + 2
     for counter in range(counter_max - 1, -1, -1):
@@ -94,9 +90,7 @@ def test_simple(filter_factory, delay, counter_max):
         tracked_objects = tracker.update()
         assert len(tracked_objects) == 1
         obj = tracked_objects[0]
-        np.testing.assert_almost_equal(
-            tracked_objects[0].estimate, np.array([[1, 1]])
-        )
+        np.testing.assert_almost_equal(tracked_objects[0].estimate, np.array([[1, 1]]))
         assert obj.age == age
         assert obj.hit_counter == counter
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -305,8 +305,12 @@ class TestPrintObjectsAsTable:
 
     def test_multiple_objects(self, capsys):
         objs = [
-            self._make_obj(id=1, age=2, hit_counter=1, last_distance=0.5, initializing_id=0),
-            self._make_obj(id=2, age=3, hit_counter=2, last_distance=1.0, initializing_id=1),
+            self._make_obj(
+                id=1, age=2, hit_counter=1, last_distance=0.5, initializing_id=0
+            ),
+            self._make_obj(
+                id=2, age=3, hit_counter=2, last_distance=1.0, initializing_id=1
+            ),
         ]
         print_objects_as_table(objs)
         out = capsys.readouterr().out
@@ -314,7 +318,9 @@ class TestPrintObjectsAsTable:
         assert "2" in out
 
     def test_none_last_distance_shows_question_mark(self, capsys):
-        obj = self._make_obj(id=1, age=1, hit_counter=1, last_distance=None, initializing_id=0)
+        obj = self._make_obj(
+            id=1, age=1, hit_counter=1, last_distance=None, initializing_id=0
+        )
         print_objects_as_table([obj])
         out = capsys.readouterr().out
         assert "?" in out

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,31 +1,175 @@
-"""Tests for norfair.utils -- get_cutout and print_objects_as_table."""
+"""Tests for norfair.utils -- comprehensive coverage of all public utilities."""
 
 import logging
+from unittest import mock
 
 import numpy as np
 import pytest
 
-from norfair.utils import get_cutout, print_objects_as_table
+from norfair.utils import (
+    DummyMOTMetricsImport,
+    DummyOpenCVImport,
+    get_cutout,
+    get_terminal_size,
+    print_objects_as_table,
+    raise_detection_error_message,
+    validate_points,
+    warn_once,
+)
 
 
+# ---------------------------------------------------------------------------
+# validate_points
+# ---------------------------------------------------------------------------
+class TestValidatePoints:
+    """Tests for validate_points: 1D reshape, 2D passthrough, 3D+ rejection."""
+
+    def test_1d_input_reshaped_to_2d(self):
+        pts = np.array([10, 20])
+        result = validate_points(pts)
+        assert result.shape == (1, 2)
+        np.testing.assert_array_equal(result, [[10, 20]])
+
+    def test_1d_single_value(self):
+        pts = np.array([5])
+        result = validate_points(pts)
+        assert result.shape == (1, 1)
+
+    def test_1d_many_values(self):
+        pts = np.array([1, 2, 3, 4])
+        result = validate_points(pts)
+        assert result.shape == (1, 4)
+
+    def test_2d_passthrough(self):
+        pts = np.array([[1, 2], [3, 4]])
+        result = validate_points(pts)
+        assert result.shape == (2, 2)
+        np.testing.assert_array_equal(result, pts)
+
+    def test_2d_single_row_passthrough(self):
+        pts = np.array([[7, 8]])
+        result = validate_points(pts)
+        assert result.shape == (1, 2)
+        np.testing.assert_array_equal(result, [[7, 8]])
+
+    def test_3d_raises_value_error(self):
+        pts = np.ones((2, 3, 4))
+        with pytest.raises(ValueError):
+            validate_points(pts)
+
+    def test_4d_raises_value_error(self):
+        pts = np.ones((1, 2, 3, 4))
+        with pytest.raises(ValueError):
+            validate_points(pts)
+
+
+# ---------------------------------------------------------------------------
+# raise_detection_error_message
+# ---------------------------------------------------------------------------
+class TestRaiseDetectionErrorMessage:
+    """Tests for raise_detection_error_message."""
+
+    def test_raises_value_error(self):
+        pts = np.ones((2, 3, 4))
+        with pytest.raises(ValueError):
+            raise_detection_error_message(pts)
+
+    def test_message_contains_shape(self):
+        pts = np.ones((2, 3, 4))
+        with pytest.raises(ValueError, match=r"\(2, 3, 4\)"):
+            raise_detection_error_message(pts)
+
+    def test_message_mentions_detection(self):
+        pts = np.ones((5, 5, 5))
+        with pytest.raises(ValueError, match="Detection"):
+            raise_detection_error_message(pts)
+
+    def test_message_contains_documentation_link(self):
+        pts = np.ones((2, 3, 4))
+        with pytest.raises(ValueError, match="https://"):
+            raise_detection_error_message(pts)
+
+
+# ---------------------------------------------------------------------------
+# get_cutout
+# ---------------------------------------------------------------------------
 class TestGetCutout:
-    """Tests for get_cutout input validation and clipping."""
+    """Tests for get_cutout input validation, clipping, and cropping."""
 
-    def _make_image(self, h=100, w=200):
-        return np.zeros((h, w, 3), dtype=np.uint8)
+    def _make_image(self, h=100, w=200, channels=3):
+        return np.arange(h * w * channels, dtype=np.uint8).reshape(h, w, channels)
 
-    def test_normal_cutout(self):
+    def test_normal_cutout_shape(self):
         img = self._make_image()
         points = np.array([[10, 20], [50, 60]])
         cutout = get_cutout(points, img)
+        # y: 20..60 = 40 rows, x: 10..50 = 40 cols
         assert cutout.shape == (40, 40, 3)
+
+    def test_normal_cutout_content(self):
+        img = self._make_image(h=10, w=10, channels=1)
+        points = np.array([[2, 3], [5, 7]])
+        cutout = get_cutout(points, img)
+        expected = img[3:7, 2:5]
+        np.testing.assert_array_equal(cutout, expected)
+
+    def test_single_point_degenerate(self, caplog):
+        img = self._make_image()
+        points = np.array([[10, 20]])
+        with caplog.at_level(logging.WARNING):
+            cutout = get_cutout(points, img)
+        assert cutout.size == 0
+
+    def test_coords_clipped_to_image_bounds(self):
+        img = self._make_image(h=50, w=50)
+        points = np.array([[-10, -10], [100, 100]])
+        cutout = get_cutout(points, img)
+        assert cutout.shape == (50, 50, 3)
+
+    def test_partially_out_of_bounds(self):
+        img = self._make_image(h=50, w=50)
+        points = np.array([[40, 30], [100, 100]])
+        cutout = get_cutout(points, img)
+        # x clipped to 40..50 = 10, y clipped to 30..50 = 20
+        assert cutout.shape == (20, 10, 3)
+
+    def test_negative_coords_clipped_to_zero(self):
+        img = self._make_image(h=50, w=50)
+        points = np.array([[-20, -30], [10, 15]])
+        cutout = get_cutout(points, img)
+        # x: 0..10 = 10, y: 0..15 = 15
+        assert cutout.shape == (15, 10, 3)
+
+    def test_degenerate_same_point_warns(self, caplog):
+        img = self._make_image()
+        points = np.array([[10, 20], [10, 20]])
+        with caplog.at_level(logging.WARNING):
+            cutout = get_cutout(points, img)
+        assert cutout.size == 0
+        assert "degenerate" in caplog.text
+
+    def test_degenerate_zero_width_warns(self, caplog):
+        img = self._make_image()
+        points = np.array([[10, 20], [10, 50]])  # same x
+        with caplog.at_level(logging.WARNING):
+            cutout = get_cutout(points, img)
+        assert cutout.shape[1] == 0  # zero width
+        assert "degenerate" in caplog.text
+
+    def test_degenerate_zero_height_warns(self, caplog):
+        img = self._make_image()
+        points = np.array([[10, 20], [50, 20]])  # same y
+        with caplog.at_level(logging.WARNING):
+            cutout = get_cutout(points, img)
+        assert cutout.shape[0] == 0  # zero height
+        assert "degenerate" in caplog.text
 
     def test_empty_points_raises(self):
         img = self._make_image()
         with pytest.raises(ValueError, match="empty"):
             get_cutout(np.empty((0, 2)), img)
 
-    def test_wrong_ndim_1d_raises(self):
+    def test_1d_points_raises(self):
         img = self._make_image()
         with pytest.raises(ValueError, match="shape"):
             get_cutout(np.array([1, 2]), img)
@@ -40,23 +184,88 @@ class TestGetCutout:
         with pytest.raises(ValueError, match="shape"):
             get_cutout(np.ones((2, 2, 2)), img)
 
-    def test_coords_clipped_to_image_bounds(self):
-        img = self._make_image(h=50, w=50)
-        points = np.array([[-10, -10], [100, 100]])
-        cutout = get_cutout(points, img)
-        assert cutout.shape == (50, 50, 3)
+    def test_1d_image_raises(self):
+        with pytest.raises(ValueError, match="dimension"):
+            get_cutout(np.array([[0, 0], [5, 5]]), np.array([1, 2, 3]))
 
-    def test_degenerate_same_point_warns(self, caplog):
-        img = self._make_image()
-        points = np.array([[10, 20], [10, 20]])
+    def test_grayscale_image(self):
+        img = np.zeros((50, 60), dtype=np.uint8)
+        points = np.array([[5, 10], [20, 30]])
+        cutout = get_cutout(points, img)
+        assert cutout.shape == (20, 15)
+
+    def test_list_input_converted(self):
+        img = self._make_image(h=50, w=50)
+        points = [[5, 10], [20, 30]]
+        cutout = get_cutout(points, img)
+        assert cutout.shape == (20, 15, 3)
+
+    def test_float_coordinates(self):
+        img = self._make_image(h=50, w=50)
+        points = np.array([[5.7, 10.3], [20.1, 30.9]])
+        cutout = get_cutout(points, img)
+        # int truncation: x 5..20 = 15, y 10..30 = 20
+        assert cutout.shape == (20, 15, 3)
+
+    def test_all_coords_outside_returns_empty(self, caplog):
+        img = self._make_image(h=50, w=50)
+        points = np.array([[200, 300], [400, 500]])
         with caplog.at_level(logging.WARNING):
             cutout = get_cutout(points, img)
         assert cutout.size == 0
-        assert "degenerate" in caplog.text
 
 
+# ---------------------------------------------------------------------------
+# get_terminal_size
+# ---------------------------------------------------------------------------
+class TestGetTerminalSize:
+    """Tests for get_terminal_size."""
+
+    def test_returns_tuple_of_two_ints(self):
+        result = get_terminal_size()
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        assert isinstance(result[0], int)
+        assert isinstance(result[1], int)
+
+    def test_default_values_used_on_os_error(self):
+        with mock.patch("os.get_terminal_size", side_effect=OSError):
+            result = get_terminal_size()
+        assert result == (80, 24)
+
+    def test_custom_default(self):
+        with mock.patch("os.get_terminal_size", side_effect=OSError):
+            result = get_terminal_size(default=(120, 40))
+        assert result == (120, 40)
+
+    def test_successful_query_returns_real_size(self):
+        fake_size = (132, 50)
+        with mock.patch("os.get_terminal_size", return_value=fake_size):
+            result = get_terminal_size()
+        assert result == fake_size
+
+    def test_first_fd_fails_second_succeeds(self):
+        """If fd 0 raises OSError but fd 1 succeeds, use fd 1's result."""
+        fake_size = (99, 33)
+        call_count = 0
+
+        def side_effect(fd):
+            nonlocal call_count
+            call_count += 1
+            if fd == 0:
+                raise OSError("stdin not a terminal")
+            return fake_size
+
+        with mock.patch("os.get_terminal_size", side_effect=side_effect):
+            result = get_terminal_size()
+        assert result == fake_size
+
+
+# ---------------------------------------------------------------------------
+# print_objects_as_table
+# ---------------------------------------------------------------------------
 class TestPrintObjectsAsTable:
-    """Tests for print_objects_as_table attribute-safety."""
+    """Tests for print_objects_as_table attribute-safety and output."""
 
     def _make_obj(self, **kwargs):
         class _Obj:
@@ -88,5 +297,117 @@ class TestPrintObjectsAsTable:
         assert "42" in out
         assert "?" in out
 
-    def test_empty_sequence(self, capsys):
+    def test_empty_sequence_no_error(self, capsys):
         print_objects_as_table([])
+        # Should not raise; just prints an empty table
+        out = capsys.readouterr().out
+        assert isinstance(out, str)
+
+    def test_multiple_objects(self, capsys):
+        objs = [
+            self._make_obj(id=1, age=2, hit_counter=1, last_distance=0.5, initializing_id=0),
+            self._make_obj(id=2, age=3, hit_counter=2, last_distance=1.0, initializing_id=1),
+        ]
+        print_objects_as_table(objs)
+        out = capsys.readouterr().out
+        assert "1" in out
+        assert "2" in out
+
+    def test_none_last_distance_shows_question_mark(self, capsys):
+        obj = self._make_obj(id=1, age=1, hit_counter=1, last_distance=None, initializing_id=0)
+        print_objects_as_table([obj])
+        out = capsys.readouterr().out
+        assert "?" in out
+
+
+# ---------------------------------------------------------------------------
+# DummyOpenCVImport
+# ---------------------------------------------------------------------------
+class TestDummyOpenCVImport:
+    """Tests for DummyOpenCVImport placeholder."""
+
+    def test_attribute_access_raises_import_error(self):
+        dummy = DummyOpenCVImport()
+        with pytest.raises(ImportError, match="OpenCV"):
+            _ = dummy.VideoCapture
+
+    def test_any_attribute_raises(self):
+        dummy = DummyOpenCVImport()
+        with pytest.raises(ImportError):
+            _ = dummy.imread
+
+    def test_error_mentions_install_command(self):
+        dummy = DummyOpenCVImport()
+        with pytest.raises(ImportError, match="pip install"):
+            _ = dummy.something
+
+
+# ---------------------------------------------------------------------------
+# DummyMOTMetricsImport
+# ---------------------------------------------------------------------------
+class TestDummyMOTMetricsImport:
+    """Tests for DummyMOTMetricsImport placeholder."""
+
+    def test_attribute_access_raises_import_error(self):
+        dummy = DummyMOTMetricsImport()
+        with pytest.raises(ImportError, match="metrics"):
+            _ = dummy.MOTAccumulator
+
+    def test_any_attribute_raises(self):
+        dummy = DummyMOTMetricsImport()
+        with pytest.raises(ImportError):
+            _ = dummy.create
+
+    def test_error_mentions_install_command(self):
+        dummy = DummyMOTMetricsImport()
+        with pytest.raises(ImportError, match="pip install"):
+            _ = dummy.anything
+
+
+# ---------------------------------------------------------------------------
+# warn_once
+# ---------------------------------------------------------------------------
+class TestWarnOnce:
+    """Tests for warn_once caching behavior."""
+
+    def setup_method(self):
+        """Clear the warn_once cache before each test."""
+        warn_once.cache_clear()
+
+    def test_warns_on_first_call(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            warn_once("test-unique-message-alpha")
+        assert "test-unique-message-alpha" in caplog.text
+
+    def test_second_call_same_message_no_extra_warning(self, caplog):
+        warn_once.cache_clear()
+        with caplog.at_level(logging.WARNING):
+            warn_once("test-unique-message-beta")
+        first_count = caplog.text.count("test-unique-message-beta")
+
+        with caplog.at_level(logging.WARNING):
+            warn_once("test-unique-message-beta")
+        second_count = caplog.text.count("test-unique-message-beta")
+
+        assert second_count == first_count  # no new warning emitted
+
+    def test_different_messages_both_warn(self, caplog):
+        warn_once.cache_clear()
+        with caplog.at_level(logging.WARNING):
+            warn_once("msg-gamma-1")
+            warn_once("msg-gamma-2")
+        assert "msg-gamma-1" in caplog.text
+        assert "msg-gamma-2" in caplog.text
+
+    def test_cache_clear_allows_rewarn(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            warn_once("msg-delta")
+        count_after_first = caplog.text.count("msg-delta")
+
+        warn_once.cache_clear()
+
+        with caplog.at_level(logging.WARNING):
+            warn_once("msg-delta")
+        count_after_second = caplog.text.count("msg-delta")
+
+        assert count_after_second == count_after_first + 1

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -8,7 +8,7 @@ import pytest
 
 # Create a mock cv2 module and inject it before importing Video
 @pytest.fixture(scope="function", autouse=True)
-def mock_cv2():
+def mock_cv2(monkeypatch):
     """Mock OpenCV for testing without actual video files."""
     # Create mock cv2
     mock = Mock()
@@ -42,9 +42,8 @@ def mock_cv2():
     mock.resize = Mock(return_value=np.zeros((50, 50, 3), dtype=np.uint8))
     mock.destroyAllWindows = Mock()
 
-    # Inject into sys.modules
-    old_cv2 = sys.modules.get("cv2")
-    sys.modules["cv2"] = mock
+    # Inject into sys.modules via monkeypatch (auto-cleaned up)
+    monkeypatch.setitem(sys.modules, "cv2", mock)
 
     # Reload norfair.video to pick up the mocked cv2
     if "norfair.video" in sys.modules:
@@ -54,21 +53,16 @@ def mock_cv2():
 
         importlib.reload(norfair.video)
 
-    yield mock
+    try:
+        yield mock
+    finally:
+        # Reload again to restore original state
+        if "norfair.video" in sys.modules:
+            import importlib
 
-    # Restore
-    if old_cv2 is not None:
-        sys.modules["cv2"] = old_cv2
-    elif "cv2" in sys.modules:
-        del sys.modules["cv2"]
+            import norfair.video
 
-    # Reload again to restore original state
-    if "norfair.video" in sys.modules:
-        import importlib
-
-        import norfair.video
-
-        importlib.reload(norfair.video)
+            importlib.reload(norfair.video)
 
 
 def test_video_requires_input_source():


### PR DESCRIPTION
## Summary

- **test_utils.py**: 50 tests covering `validate_points`, `get_cutout`, `print_objects_as_table`, `get_terminal_size`, `warn_once`, `DummyOpenCVImport`, `DummyMOTMetricsImport`
- **test_drawing_integration.py**: 65 tests for `draw_boxes`, `draw_points`, `Paths`, `AbsolutePaths`, `FixedCamera`, `draw_absolute_grid`, NaN/Inf safety
- **test_camera_motion.py**: +23 tests for `TranslationTransformation`, `MotionEstimator`, sparse flow helpers, transformation getters
- Parametrize `test_simple` — nested for loops → `pytest.mark.parametrize` (12 named test cases)
- Fix `conftest.py` — `reset_global_count` wrapped in `try/finally`
- Fix `test_video.py` — replace `sys.modules` hack with `monkeypatch`

281 tests pass locally in 0.22s.

Closes #51

## Test plan

- [ ] CI passes on all Python versions (3.10–3.13) and OS matrix
- [ ] MOT metrics regression unaffected
- [ ] Coverage report shows improvement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved fixture reliability to guarantee global state reset before and after each test.
  * Vastly expanded test coverage for camera motion, optical flow, homography and motion estimation behavior.
  * New integration tests exercising the drawing API, rendering, and drawing-edge cases.
  * Added extensive utility tests (validation, cutouts, warnings, terminal size, error messages).
  * Consolidated and parameterized tracker tests for clearer scenarios and coverage.
  * Refined video mock handling to better restore module state after tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->