### PR TITLE
chore: release v2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This fork is based on [tryolabs/norfair](https://github.com/tryolabs/norfair) v2
 
 ## [Unreleased]
 
+## [2.4.1] - 2026-04-14
+
 ### Added
 - Comprehensive test coverage for `camera_motion`, drawing subpackage, `Video`, and utils (#76)
 - Add CodeRabbit-generated unit tests for `Video`, tracker, and package exports (#26)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "norfair-enough"
-version = "2.4.0"
+version = "2.4.1"
 description = "Lightweight Python library for adding real-time multi-object tracking to any detector. Maintained fork of tryolabs/norfair."
 license = "BSD-3-Clause"
 license-files = ["LICENSE"]

--- a/uv.lock
+++ b/uv.lock
@@ -688,7 +688,7 @@ wheels = [
 
 [[package]]
 name = "norfair-enough"
-version = "2.4.0"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

- Bump version `2.4.0` → `2.4.1` in `pyproject.toml`
- Move `[Unreleased]` changelog entries to `[2.4.1] - 2026-04-14`

After merge, the draft GitHub release will be published, triggering PyPI upload and docs deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 2.4.1
  * Changelog updated with new release entry

<!-- end of auto-generated comment: release notes by coderabbit.ai -->