### PR TITLE
fix: handle non-version aliases in deploy_docs.py

### DIFF
--- a/docs/deploy_docs.py
+++ b/docs/deploy_docs.py
@@ -26,8 +26,12 @@ def get_current_version() -> version.Version:
 def get_latest_version() -> version.Version | None:
     "Get the deployed version number tagged as `latest` in mike."
     for line in run_cmd("mike list"):
-        if line.endswith("[latest]"):
-            return version.parse(line.split()[0])
+        if "[latest]" in line:
+            try:
+                return version.parse(line.split()[0])
+            except version.InvalidVersion:
+                logger.warning("Latest deployed version %r is not a valid version, treating as None", line.split()[0])
+                return None
     logger.warning("Could not read the latest version deployed")
 
 

--- a/docs/deploy_docs.py
+++ b/docs/deploy_docs.py
@@ -30,7 +30,10 @@ def get_latest_version() -> version.Version | None:
             try:
                 return version.parse(line.split()[0])
             except version.InvalidVersion:
-                logger.warning("Latest deployed version %r is not a valid version, treating as None", line.split()[0])
+                logger.warning(
+                    "Latest deployed version %r is not a valid version, treating as None",
+                    line.split()[0],
+                )
                 return None
     logger.warning("Could not read the latest version deployed")
 


### PR DESCRIPTION
## Summary

The v2.4.1 release deployed to PyPI successfully, but `deploy-doc` failed because `mike list` returns `dev [latest]` (from prior push-to-main deployments), and `"dev"` can't be parsed as a version number.

- Catch `InvalidVersion` when parsing the `[latest]`-tagged mike entry
- Fall back to `None`, which correctly tags the new deployment as `latest`

## Test plan
- [ ] After merge, re-run the failed deploy-doc job from the v2.4.1 release workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of version detection to recognize the latest tag in more formats.
  * Added graceful handling for malformed version entries: logs a warning and treats them as absent instead of failing.
  * Retains existing behavior of returning no result when no latest version is found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->