### PR TITLE
Fix hit_counter not set to hit_counter_max on initialization

### DIFF
--- a/norfair/tracker.py
+++ b/norfair/tracker.py
@@ -413,8 +413,8 @@ class Tracker:
                             candidates_to_remove.add(id(matched_candidate))
                     else:
                         unmatched_candidates.append(
-                            matched_candidate
-                        )  # pyrefly: ignore[bad-argument-type]
+                            matched_candidate  # pyrefly: ignore[bad-argument-type]
+                        )
                         unmatched_objects.append(matched_object)
 
                 # Batch-remove merged TrackedObject candidates in a single pass (O(n))
@@ -789,6 +789,7 @@ class TrackedObject:
         if self.is_initializing and self.hit_counter > self.initialization_delay:
             self.is_initializing = False
             self._acquire_ids()
+            self.hit_counter = self.hit_counter_max
 
         # Reset reid_hit_counter if we are are successfully tracking this object.
         # If hit_counter was 0 when Tracker.update was called and ReID is being used,

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -71,7 +71,11 @@ def test_simple(filter_factory, delay, counter_max):
         obj = tracked_objects[0]
         np.testing.assert_almost_equal(tracked_objects[0].estimate, np.array([[1, 1]]))
         assert obj.age == age
-        assert obj.hit_counter == age + 1
+        if delay > 0:
+            # After initialization, hit_counter jumps to counter_max
+            assert obj.hit_counter == counter_max
+        else:
+            assert obj.hit_counter == age + 1
 
     # check that counter is capped at counter_max
     for age in range(counter_max, counter_max + 3):
@@ -239,7 +243,9 @@ def test_count(delay):
         assert tracker.total_object_count == 1
         assert tracker.current_object_count == 1
 
-        for _ in range(delay + 1, 0, -1):
+        # After initialization, hit_counter is counter_max (for delay>0) or 1 (for delay==0)
+        survive_frames = counter_max if delay > 0 else 1
+        for _ in range(survive_frames, 0, -1):
             assert len(tracker.update()) == 1
             assert tracker.total_object_count == 1
             assert tracker.current_object_count == 1
@@ -262,7 +268,7 @@ def test_count(delay):
         assert tracker.total_object_count == 3
         assert tracker.current_object_count == 2
 
-        for _ in range(delay + 1, 0, -1):
+        for _ in range(survive_frames, 0, -1):
             assert len(tracker.update()) == 2
             assert tracker.total_object_count == 3
             assert tracker.current_object_count == 2
@@ -526,6 +532,38 @@ def test_nan_distance_raises():
     tracker.update([Detection(points=np.array([[1, 1]]))])
     with pytest.raises(ValueError, match="nan"):
         tracker.update([Detection(points=np.array([[1, 1]]))])
+
+
+def test_hit_counter_max_after_initialization():
+    """hit_counter must equal hit_counter_max once a tracked object is initialized.
+
+    Regression test for https://github.com/tryolabs/norfair/issues/337
+    A newly initialized object used to keep its low hit_counter (≈ period)
+    instead of receiving the full hit_counter_max buffer, causing it to
+    disappear after only a few frames without detection.
+    """
+    tracker = Tracker(
+        distance_function="euclidean",
+        distance_threshold=100,
+        hit_counter_max=600,
+        initialization_delay=2,
+    )
+
+    det = [Detection(points=np.array([[1, 1]]))]
+
+    # First two updates: object is still initializing
+    assert len(tracker.update(det)) == 0
+    assert len(tracker.update(det)) == 0
+
+    # Third update: object transitions to initialized
+    tracked = tracker.update(det)
+    assert len(tracked) == 1
+    assert tracked[0].hit_counter == 600  # must be hit_counter_max, not ~6
+
+    # Object must survive many frames without detection
+    for i in range(500):
+        tracked = tracker.update([])
+        assert len(tracked) == 1, f"Object died after {i + 1} frames without detection"
 
 
 def test_period_parameter():


### PR DESCRIPTION
## Summary

- **Fixes #81** (upstream: https://github.com/tryolabs/norfair/issues/337)
- When a `TrackedObject` transitioned from initializing to initialized, `hit_counter` kept its low value (~`period`) instead of being set to `hit_counter_max`. This caused newly initialized objects to disappear after only a few frames without detection — regardless of the configured `hit_counter_max`.
- Sets `hit_counter = hit_counter_max` at the initialization transition point in `TrackedObject.hit()`.

## Test plan

- [x] Added regression test `test_hit_counter_max_after_initialization` that reproduces the exact scenario from the bug report (`hit_counter_max=600`, `initialization_delay=2`, verifies object survives 500+ frames)
- [x] Updated existing `test_simple` and `test_count` assertions to match corrected behavior
- [x] All 282 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tracked object counter behavior to correctly set to its maximum value when initialization is complete.

* **Tests**
  * Enhanced test suite with additional coverage for object tracking initialization behavior, including new regression tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->