### PR TITLE
chore: release v2.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This fork is based on [tryolabs/norfair](https://github.com/tryolabs/norfair) v2
 
 ## [Unreleased]
 
+## [2.4.2] - 2026-04-16
+
+### Fixed
+- Fix `hit_counter` not set to `hit_counter_max` on initialization, causing newly tracked objects to exit after a few frames without detection (#82). Upstream: [tryolabs/norfair#337](https://github.com/tryolabs/norfair/issues/337)
+
 ## [2.4.1] - 2026-04-14
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "norfair-enough"
-version = "2.4.1"
+version = "2.4.2"
 description = "Lightweight Python library for adding real-time multi-object tracking to any detector. Maintained fork of tryolabs/norfair."
 license = "BSD-3-Clause"
 license-files = ["LICENSE"]

--- a/uv.lock
+++ b/uv.lock
@@ -688,7 +688,7 @@ wheels = [
 
 [[package]]
 name = "norfair-enough"
-version = "2.4.1"
+version = "2.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

- Bump version to 2.4.2
- Update CHANGELOG with fix from #82

## Changes in this release

### Fixed
- `hit_counter` not set to `hit_counter_max` on initialization, causing newly tracked objects to exit after a few frames without detection (#82). Upstream: tryolabs/norfair#337

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where newly tracked objects would exit the tracking system prematurely after a few frames without detection. This correction ensures that object tracking correctly maintains state during temporary detection gaps, resulting in more stable and reliable tracking behavior as objects initially enter and are tracked by the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->