### PR TITLE
fix(camera_motion): raise ValueError for singular homography

### DIFF
--- a/norfair/camera_motion.py
+++ b/norfair/camera_motion.py
@@ -217,9 +217,23 @@ class HomographyTransformation(CoordinatesTransformation):
     """
 
     def __init__(self, homography_matrix: np.ndarray):
-        """Store the homography and pre-compute its inverse."""
+        """Store the homography and pre-compute its inverse.
+
+        Raises
+        ------
+        ValueError
+            If ``homography_matrix`` is singular (non-invertible) and no
+            mapping back from relative to absolute coordinates is possible.
+        """
         self.homography_matrix = homography_matrix
-        self.inverse_homography_matrix = np.linalg.inv(homography_matrix)
+        try:
+            self.inverse_homography_matrix = np.linalg.inv(homography_matrix)
+        except np.linalg.LinAlgError as exc:
+            raise ValueError(
+                "homography_matrix is singular (non-invertible); cannot compute "
+                "rel_to_abs transform. Check your homography estimation "
+                "(e.g. degenerate point configuration)."
+            ) from exc
 
     def abs_to_rel(self, points: NDArray[np.float64]) -> NDArray[np.float64]:
         """Apply the forward homography to map absolute points to relative.

--- a/tests/test_camera_motion.py
+++ b/tests/test_camera_motion.py
@@ -8,6 +8,20 @@ from norfair.camera_motion import (
 )
 
 
+def test_homography_singular_matrix_raises_value_error():
+    """Singular homography matrices should raise a clear ``ValueError`` (#86)."""
+    # Row of zeros => determinant 0 => matrix is singular.
+    singular = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    with pytest.raises(ValueError, match="singular|invertible"):
+        HomographyTransformation(singular)
+
+
 def test_homography_1d_point():
     """Test that HomographyTransformation handles 1D point arrays without crashing."""
     # Identity homography — points should pass through unchanged

--- a/tests/test_camera_motion.py
+++ b/tests/test_camera_motion.py
@@ -9,7 +9,7 @@ from norfair.camera_motion import (
 
 
 def test_homography_singular_matrix_raises_value_error():
-    """Singular homography matrices should raise a clear ``ValueError`` (#86)."""
+    """Singular homography matrices raise ``ValueError``."""
     # Row of zeros => determinant 0 => matrix is singular.
     singular = np.array(
         [


### PR DESCRIPTION
## Summary
- `HomographyTransformation.__init__` now catches `LinAlgError` from `np.linalg.inv` and re-raises as `ValueError` with an actionable message.
- Adds a regression test for a singular 3×3 matrix.

## Test plan
- [x] New test `test_homography_singular_matrix_raises_value_error` fails on main, passes with the fix.
- [x] Full unit-test suite (`uv run pytest tests/ --ignore=tests/mot_metrics.py`) green (283 passed).
- [x] `ruff check` and `ruff format --check` clean.

Closes #86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling and clearer error messaging when a provided homography matrix is singular or non-invertible, preventing obscure failures.

* **Tests**
  * Added a test that verifies the new error is raised and reported clearly for invalid homography inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->