### PR TITLE
refactor(utils): drop rich.print that shadowed built-in

### DIFF
--- a/norfair/utils.py
+++ b/norfair/utils.py
@@ -7,7 +7,6 @@ from logging import warning
 
 import numpy as np
 from numpy.typing import NDArray
-from rich import print
 from rich.console import Console
 from rich.table import Table
 


### PR DESCRIPTION
## Summary
- Remove `from rich import print` — the only call site is a `print()` blank-line, for which the built-in is equivalent. Prevents ANSI-escape leakage into redirected logs.

## Test plan
- [x] 282 tests pass.
- [x] Ruff clean.

Closes #101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced external dependencies in utility module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->