### PR TITLE
docs: announce end of maintenance and correct two stale claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,20 @@
 [![Docs](https://img.shields.io/badge/docs-dev-blue)](https://akator-de.github.io/norfair-enough/)
 [![License](https://img.shields.io/github/license/akator-de/norfair-enough)](https://github.com/akator-de/norfair-enough/blob/main/LICENSE)
 
-**A maintained fork of [tryolabs/norfair](https://github.com/tryolabs/norfair)** — lightweight Python library for real-time multi-object tracking.
+**A fork of [tryolabs/norfair](https://github.com/tryolabs/norfair)** — lightweight Python library for real-time multi-object tracking.
 
-The upstream Norfair repository is no longer actively maintained. This fork keeps the library alive for production use. There is no claim to be the official successor — just a pragmatic continuation. New maintainers are welcome.
+> [!IMPORTANT]
+> **This fork is no longer maintained. [v2.4.3](https://github.com/akator-de/norfair-enough/releases/tag/v2.4.3) (August 2026) is the final release, and this repository is archived and read-only.**
+>
+> It was created and kept current for a production project that has since ended, so there is no longer anything driving its maintenance.
+>
+> - **The package still works.** `pip install norfair-enough` continues to work. v2.4.3 supports Python 3.10–3.13, NumPy 2.x, and OpenCV from 4.10.0.84 through 5.x.
+> - **Nothing further will be released** — no fixes, no dependency updates, no issue or pull request review.
+> - **Forking is welcome.** The code is BSD-3-Clause with no copyleft restrictions. If you want to carry it forward, fork it and publish under your own name; nothing beyond the license terms is expected.
+>
+> Upstream [tryolabs/norfair](https://github.com/tryolabs/norfair) has had no commits since April 2025, so it is not an actively maintained alternative either. See [Comparison to other trackers](#comparison-to-other-trackers) for options that are.
+
+This fork existed to keep the library usable in production while upstream was dormant. It never claimed to be the official successor — it was a pragmatic continuation.
 
 |                                           Tracking players with moving camera                                           |                                           Tracking 3D objects                                           |
 | :---------------------------------------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------------------: |
@@ -139,7 +150,7 @@ Norfair Enough stands out by being **detector-agnostic**, supporting **any point
 
 ## Benchmarks
 
-These benchmarks were produced using the [motmetrics4norfair](https://github.com/akator-de/norfair-enough/tree/main/demos/motmetrics4norfair) demo script. Our CI runs MOT metrics regression tests on every pull request to prevent tracking quality regressions.
+These benchmarks were produced using the [motmetrics4norfair](https://github.com/akator-de/norfair-enough/tree/main/demos/motmetrics4norfair) demo script, which is still included if you want to reproduce them.
 
 [MOT17](https://motchallenge.net/data/MOT17/) and [MOT20](https://motchallenge.net/data/MOT20/) results obtained using [motmetrics4norfair](https://github.com/akator-de/norfair-enough/tree/main/demos/motmetrics4norfair) demo script on the `train` split. We used detections obtained with [ByteTrack's](https://github.com/ifzhang/ByteTrack) YOLOX object detection model.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 >
 > It was created and kept current for a production project that has since ended, so there is no longer anything driving its maintenance.
 >
-> - **The package still works.** `pip install norfair-enough` continues to work. v2.4.3 supports Python 3.10–3.13, NumPy 2.x, and OpenCV from 4.10.0.84 through 5.x.
+> - **The package still works.** `pip install norfair-enough` continues to work. v2.4.3 declares Python 3.10+ and was tested through 3.13; it supports NumPy 2.x and OpenCV from 4.10.0.84 through 5.x. Newer Python releases will install but were never covered by CI.
 > - **Nothing further will be released** — no fixes, no dependency updates, no issue or pull request review.
 > - **Forking is welcome.** The code is BSD-3-Clause with no copyleft restrictions. If you want to carry it forward, fork it and publish under your own name; nothing beyond the license terms is expected.
 >

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,8 +1,14 @@
 # Migration Guide: tryolabs/norfair → norfair-enough
 
-`norfair-enough` is a maintained fork of [`tryolabs/norfair`](https://github.com/tryolabs/norfair),
+`norfair-enough` is a fork of [`tryolabs/norfair`](https://github.com/tryolabs/norfair),
 based on upstream v2.3.0. This guide describes what you need to change when moving an existing
 project from the upstream package to `norfair-enough`.
+
+!!! warning "This fork is no longer maintained"
+
+    v2.4.3 (August 2026) is the final release and the repository is archived. The package
+    remains installable and working, but nothing further will be released. This guide is kept
+    for anyone migrating onto that final version, or forking it to carry it forward.
 
 ## TL;DR
 
@@ -153,8 +159,13 @@ Old imports continue to work.
 
 ## Staying on upstream `tryolabs/norfair`
 
-Upstream `tryolabs/norfair` is no longer actively maintained. If you prefer to stay on it,
+Upstream `tryolabs/norfair` has had no commits since April 2025. If you prefer to stay on it,
 you can continue to install it from
 [its repository](https://github.com/tryolabs/norfair) or PyPI — but be aware that bug fixes
-and new Python/NumPy compatibility work will not flow back. `norfair-enough` exists precisely
-to keep this codebase alive for users who need it.
+and new Python/NumPy compatibility work will not flow back.
+
+Both projects are now dormant. `norfair-enough` v2.4.3 carries the fixes listed above and
+supports current Python, NumPy 2.x and OpenCV 5, so it is the further-along of the two — but
+if you need something under active development, the alternatives listed in the
+[README](https://github.com/akator-de/norfair-enough#comparison-to-other-trackers) are the
+better starting point.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -165,7 +165,8 @@ you can continue to install it from
 and new Python/NumPy compatibility work will not flow back.
 
 Both projects are now dormant. `norfair-enough` v2.4.3 carries the fixes listed above and
-supports current Python, NumPy 2.x and OpenCV 5, so it is the further-along of the two — but
-if you need something under active development, the alternatives listed in the
+requires Python 3.10+ (tested through 3.13), NumPy 2.x and OpenCV 5, so it is the
+further-along of the two — but if you need something under active development, the
+alternatives listed in the
 [README](https://github.com/akator-de/norfair-enough#comparison-to-other-trackers) are the
 better starting point.


### PR DESCRIPTION
Prepares the repository for archiving.

## README status callout

States plainly that v2.4.3 is the final release, that the package still installs and works, and that forking is welcome under BSD-3. Placed directly under the intro, since that is what someone arriving from [tryolabs/norfair#336](https://github.com/tryolabs/norfair/issues/336) reads first. `docs/gen_index.py` renders the README as the docs homepage, so the notice also lands on the published site.

## Two corrections

- **README benchmarks section** claimed "Our CI runs MOT metrics regression tests on every pull request." #123 removed the MOT17 integration test, and no workflow contains a MOT job — verified against `.github/workflows/`. The demo script is still there, so the wording now says the benchmarks are reproducible with it.
- **Migration guide** introduced this fork as maintained and closed with "norfair-enough exists precisely to keep this codebase alive." Both projects are dormant now; it points at the actively developed alternatives instead.

Docs build verified locally. The one remaining mkdocs warning (`norfair.drawing` cross-reference in migration.md:93) is pre-existing — reproduced on unmodified `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project documentation to clarify that the fork is archived and v2.4.3 is the final release.
  * Documented supported Python, NumPy, and OpenCV versions, installation guidance, and forking options.
  * Revised migration guidance with updated upstream status and recommendations for maintained alternatives.
  * Clarified that benchmark demos remain available for reproducing results, while CI regression testing is no longer claimed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->